### PR TITLE
Bugfix upon restart 

### DIFF
--- a/src/JacRes.cpp
+++ b/src/JacRes.cpp
@@ -1930,9 +1930,11 @@ PetscErrorCode JacResCopyPres(JacRes *jr, Vec x)
 	PetscFunctionReturn(0);
 }
 //---------------------------------------------------------------------------
-PetscErrorCode JacResInitPres(JacRes *jr)
+PetscErrorCode JacResInitPres(JacRes *jr,TSSol *ts)
+
 {
 	FDSTAG            *fs;
+	
 	BCCtx             *bc;
 	SolVarCell        *svCell;
 	const PetscScalar *p;
@@ -1949,7 +1951,7 @@ PetscErrorCode JacResInitPres(JacRes *jr)
 	fixPhase = bc->fixPhase;
 
 	// check activation
-	if(!bc->initPres) PetscFunctionReturn(0);
+	if(!bc->initPres || ts->istep>0) PetscFunctionReturn(0);
 
 	// get grid coordinate bounds in z-direction
 	ierr = FDSTAGGetGlobalBox(fs, NULL, NULL, &bz, NULL, NULL, &ez); CHKERRQ(ierr);
@@ -1999,7 +2001,7 @@ PetscErrorCode JacResInitPres(JacRes *jr)
 	PetscFunctionReturn(0);
 }
 //---------------------------------------------------------------------------
-PetscErrorCode JacResInitLithPres(JacRes *jr, AdvCtx *actx)
+PetscErrorCode JacResInitLithPres(JacRes *jr, AdvCtx *actx,TSSol *ts)
 {
 	FDSTAG            *fs;
 	SolVarCell        *svCell;
@@ -2015,7 +2017,7 @@ PetscErrorCode JacResInitLithPres(JacRes *jr, AdvCtx *actx)
 	PetscFunctionBeginUser;
 
 	// check activation
-	if(!jr->ctrl.initLithPres) PetscFunctionReturn(0);
+	if(!jr->ctrl.initLithPres || ts->istep >0) PetscFunctionReturn(0);
 
 	// print
 	PrintStart(&t, "Initializing pressure with lithostatic pressure", NULL);

--- a/src/JacRes.h
+++ b/src/JacRes.h
@@ -313,10 +313,10 @@ PetscErrorCode JacResCopyVel(JacRes *jr, Vec x);
 PetscErrorCode JacResCopyPres(JacRes *jr, Vec x);
 
 // initialize pressure
-PetscErrorCode JacResInitPres(JacRes *jr);
+PetscErrorCode JacResInitPres(JacRes *jr,TSSol *ts);
 
 // initialize pressure to lithostatic pressure
-PetscErrorCode JacResInitLithPres(JacRes *jr, AdvCtx *actx);
+PetscErrorCode JacResInitLithPres(JacRes *jr, AdvCtx *actx, TSSol *ts);
 
 // copy residuals from local to global vectors, enforce boundary constraints
 PetscErrorCode JacResCopyRes(JacRes *jr, Vec f);

--- a/src/LaMEMLib.cpp
+++ b/src/LaMEMLib.cpp
@@ -905,7 +905,7 @@ PetscErrorCode LaMEMLibDiffuseTemp(LaMEMLib *lm)
 	}
 
 	// check for additional limited diffusion
-	if (ctrl->actTemp && ctrl->steadyTempStep)
+	if (ctrl->actTemp && ctrl->steadyTempStep && ts->istep==0)
 	{
 		PrintStart(&t,"Diffusing temperature", NULL);
 

--- a/src/LaMEMLib.cpp
+++ b/src/LaMEMLib.cpp
@@ -822,10 +822,10 @@ PetscErrorCode LaMEMLibInitGuess(LaMEMLib *lm, SNES snes)
 	ierr = LaMEMLibDiffuseTemp(lm); CHKERRQ(ierr);
 
 	// initialize pressure
-	ierr = JacResInitPres(&lm->jr); CHKERRQ(ierr);
+	ierr = JacResInitPres(&lm->jr,&lm->ts); CHKERRQ(ierr);
 
 	// lithostatic pressure initializtaion
-	ierr = JacResInitLithPres(&lm->jr, &lm->actx); CHKERRQ(ierr);
+	ierr = JacResInitLithPres(&lm->jr, &lm->actx, &lm->ts); CHKERRQ(ierr);
 
 	// compute inverse elastic parameters (dependent on dt)
 	ierr = JacResGetI2Gdt(&lm->jr); CHKERRQ(ierr);
@@ -864,6 +864,7 @@ PetscErrorCode LaMEMLibInitGuess(LaMEMLib *lm, SNES snes)
 PetscErrorCode LaMEMLibDiffuseTemp(LaMEMLib *lm)
 {
 	JacRes         *jr;
+	TSSol          *ts;
 	Controls       *ctrl;
 	AdvCtx         *actx;
 	PetscLogDouble t;
@@ -874,12 +875,13 @@ PetscErrorCode LaMEMLibDiffuseTemp(LaMEMLib *lm)
 	PetscFunctionBeginUser;
 
 	// access context
+	ts       = &lm->ts; 
 	jr      = &lm->jr;
 	ctrl    = &jr->ctrl;
 	actx    = &lm->actx;
 
 	// check for infinite diffusion
-	if (ctrl->actTemp && ctrl->actSteadyTemp)
+	if (ctrl->actTemp && ctrl->actSteadyTemp && ts->istep<=1)
 	{
 		PrintStart(&t,"Computing steady-state temperature distribution", NULL);
 

--- a/src/LaMEMLib.cpp
+++ b/src/LaMEMLib.cpp
@@ -629,7 +629,7 @@ PetscErrorCode LaMEMLibSolve(LaMEMLib *lm, void *param, PetscLogStage stages[4])
 	PetscCall(PetscLogStagePush(stages[0])); /* Start profiling stage*/
 
 	ierr = LaMEMLibInitGuess(lm, snes); CHKERRQ(ierr);
-    
+
 	PetscCall(PetscLogStagePop()); /* Stop profiling stage*/
 
 	if (param)
@@ -881,7 +881,7 @@ PetscErrorCode LaMEMLibDiffuseTemp(LaMEMLib *lm)
 	actx    = &lm->actx;
 
 	// check for infinite diffusion
-	if (ctrl->actTemp && ctrl->actSteadyTemp && ts->istep<=1)
+	if (ctrl->actTemp && ctrl->actSteadyTemp && ts->istep==0)
 	{
 		PrintStart(&t,"Computing steady-state temperature distribution", NULL);
 


### PR DESCRIPTION
1] If the steady state temperature field, the diffusion temperature time step, or the initial lithostatic pressure are activated, they are performed also after restarting the simulation: 
a.) This implies that the vector of pressure from the restart database is overwritten by the guess of lithostatic pressure (**=BAD**). 
b.) This implies that the current temperature field coming from the restart database will be modified. 
2] This PR introduces a solution: 
-> TSSolve is an argument of these function: if the timestep is different than 0, these function are not applied. 
