### PR TITLE
Plasticity regularisation

### DIFF
--- a/input_models/input/lamem_input.dat
+++ b/input_models/input/lamem_input.dat
@@ -768,7 +768,8 @@
         TRef_fk    = 1000.0 # reference Temperature for Frank-Kamenetzky viscosity (if not set it is 0°C) 
         ch         = 2e7    # cohesion
         fr         = 30.0   # friction angle
-        eta_st     = 1e19   # stabilization viscosity (default is eta_min)
+        eta_st     = 1e19   # stabilization viscosity (minimum viscosity for this phase; default is eta_min)
+        eta_vp     = 1e19   # viscoplastic regularisation viscosity (increases yield stress as tau_y += eta_vp*DIIpl where DIIpl is the plastic strainrate)
         rp         = 0.7    # pore-pressure ratio
         chSoftID   = 0      # friction softening law ID
         frSoftID   = 0      # cohesion softening law ID

--- a/src/JacRes.cpp
+++ b/src/JacRes.cpp
@@ -148,7 +148,7 @@ PetscErrorCode JacResCreate(JacRes *jr, FB *fb)
 		||  (m->Kb || m->beta))       need_top_open  = 1;
 
 		// set default stabilization viscosity
-		//if(!m->eta_st) m->eta_st = ctrl->eta_min/scal->viscosity;
+		if(!m->eta_st) m->eta_st = ctrl->eta_min/scal->viscosity;
 
 	}
 

--- a/src/JacRes.h
+++ b/src/JacRes.h
@@ -35,6 +35,8 @@ struct SolVarDev
 {
 	PetscScalar  eta;    // total effective viscosity
 	PetscScalar  eta_st; // stabilization viscosity
+	PetscScalar  eta_vp; // viscoplastic viscosity
+	
 	PetscScalar  I2Gdt;  // inverse elastic parameter (1/2G/dt)
 	PetscScalar  Hr;     // shear heating term contribution
 	PetscScalar  APS;    // accumulated plastic strain

--- a/src/JacRes.h
+++ b/src/JacRes.h
@@ -25,7 +25,6 @@ struct Dike;
 struct Tensor2RN;
 struct PData;
 struct AdvCtx;
-//struct ConstEqCtx;
 
 //---------------------------------------------------------------------------
 //.....................   Deviatoric solution variables   ...................
@@ -35,8 +34,6 @@ struct SolVarDev
 {
 	PetscScalar  eta;    // total effective viscosity
 	PetscScalar  eta_st; // stabilization viscosity
-	PetscScalar  eta_vp; // viscoplastic viscosity
-	
 	PetscScalar  I2Gdt;  // inverse elastic parameter (1/2G/dt)
 	PetscScalar  Hr;     // shear heating term contribution
 	PetscScalar  APS;    // accumulated plastic strain

--- a/src/constEq.cpp
+++ b/src/constEq.cpp
@@ -437,7 +437,7 @@ PetscErrorCode getPhaseVisc(ConstEqCtx *ctx, PetscInt ID)
 			DIIpl_0 = DIIpl;
 
 			// Add viscoplastic regularization 
-			taupl = taupl0 +  ctx->eta_vp*DIIpl;	// add regularisation based on plastic strain rate
+			taupl = taupl0 +  2.0*ctx->eta_vp*DIIpl;	// add regularisation based on plastic strain rate
 			tauII = taupl; 	
 			eta   = tauII/(2.0*DII);
 

--- a/src/constEq.h
+++ b/src/constEq.h
@@ -40,7 +40,7 @@ struct ConstEqCtx
 	Material_t  *phases;    	// phase parameters
 	Soft_t      *soft;      	// material softening laws
 	Ph_trans_t  *PhaseTrans;    // Phase transition laws
-  PetscInt  numPhtr; // number of phase transitions laws
+    PetscInt    numPhtr;        // number of phase transitions laws
     DBMat       *dbm;
     DBPropDike  *dbdike;
     Dike        *matDike;       // material properties of dike
@@ -75,6 +75,8 @@ struct ConstEqCtx
 	PetscScalar  N_prl;  // Peierls exponent
 	PetscScalar  A_fk;   // Frank-Kamenetzky constant
 	PetscScalar  taupl;  // plastic yield stress
+	PetscScalar  eta_vp; // viscoplastic regularisation
+	
 
 	// control volume results
 	PetscScalar  eta;    // effective viscosity

--- a/src/constEq.h
+++ b/src/constEq.h
@@ -75,7 +75,7 @@ struct ConstEqCtx
 	PetscScalar  N_prl;  // Peierls exponent
 	PetscScalar  A_fk;   // Frank-Kamenetzky constant
 	PetscScalar  taupl;  // plastic yield stress
-	PetscScalar  eta_vp; // viscoplastic regularisation
+	PetscScalar  eta_vp; // regularization viscosity
 	
 
 	// control volume results

--- a/src/phase.cpp
+++ b/src/phase.cpp
@@ -460,8 +460,10 @@ PetscErrorCode DBMatReadPhase(DBMat *dbm, FB *fb, PetscBool PrintOutput)
 	ierr = getScalarParam(fb, _OPTIONAL_, "rho_melt", &m->rho_melt,1, 1.0);  CHKERRQ(ierr);
 
 	if (PrintOutput)
-	{
-		PetscPrintf(PETSC_COMM_WORLD,"- Melt factor mfc = %f", m->mfc);
+	{	
+		if (m->mfc>0){
+			PetscPrintf(PETSC_COMM_WORLD,"- Melt factor mfc = %f", m->mfc);
+		}
 	}
 
 	// check energy parameters

--- a/src/phase.cpp
+++ b/src/phase.cpp
@@ -253,7 +253,7 @@ PetscErrorCode DBMatReadPhase(DBMat *dbm, FB *fb, PetscBool PrintOutput)
 	Material_t *m;
 	PetscInt    ID = -1, visID = -1, chSoftID, frSoftID, healID, MSN, print_title;
 	size_t 	    StringLength;
-	PetscScalar eta, eta0, e0, Kb, G, E, Vp, Vs, eta_st, nu;
+	PetscScalar eta, eta0, e0, Kb, G, E, Vp, Vs, eta_st, eta_vp, nu;
 	char        ndiff[_str_len_], ndisl[_str_len_], npeir[_str_len_], title[_str_len_];
 	char        PhaseDiagram[_str_len_], PhaseDiagram_Dir[_str_len_], Name[_str_len_];
 
@@ -275,6 +275,8 @@ PetscErrorCode DBMatReadPhase(DBMat *dbm, FB *fb, PetscBool PrintOutput)
 	Vp       =  0.0;
 	Vs       =  0.0;
 	eta_st   =  0.0;
+	eta_vp   =  0.0;
+	
 	chSoftID = -1;
 	frSoftID = -1;
 	healID   = -1;
@@ -432,6 +434,7 @@ PetscErrorCode DBMatReadPhase(DBMat *dbm, FB *fb, PetscBool PrintOutput)
 	ierr = getScalarParam(fb, _OPTIONAL_, "ch",       &m->ch,     1, 1.0); CHKERRQ(ierr);
 	ierr = getScalarParam(fb, _OPTIONAL_, "fr",       &m->fr,     1, 1.0); CHKERRQ(ierr);
 	ierr = getScalarParam(fb, _OPTIONAL_, "eta_st",   &eta_st,    1, 1.0); CHKERRQ(ierr);
+	ierr = getScalarParam(fb, _OPTIONAL_, "eta_vp",   &eta_vp,    1, 1.0); CHKERRQ(ierr);
 	ierr = getScalarParam(fb, _OPTIONAL_, "rp",       &m->rp,     1, 1.0); CHKERRQ(ierr);
 	ierr = getIntParam   (fb, _OPTIONAL_, "chSoftID", &chSoftID,  1, MSN); CHKERRQ(ierr);
 	ierr = getIntParam   (fb, _OPTIONAL_, "frSoftID", &frSoftID,  1, MSN); CHKERRQ(ierr);
@@ -506,7 +509,8 @@ PetscErrorCode DBMatReadPhase(DBMat *dbm, FB *fb, PetscBool PrintOutput)
 
 
 	m->eta_st   = eta_st;
-   
+	m->eta_vp   = eta_vp;
+	
 	// set softening law IDs
 	m->chSoftID = chSoftID;
 	m->frSoftID = frSoftID;
@@ -710,6 +714,7 @@ PetscErrorCode DBMatReadPhase(DBMat *dbm, FB *fb, PetscBool PrintOutput)
 		MatPrintScalParam(m->ch,     "ch",     "[Pa]",   scal, title, &print_title);
 		MatPrintScalParam(m->fr,     "fr",     "[deg]",  scal, title, &print_title);
 		MatPrintScalParam(m->eta_st, "eta_st", "[Pa*s]", scal, title, &print_title);
+		MatPrintScalParam(m->eta_vp, "eta_vp", "[Pa*s]", scal, title, &print_title);
 		MatPrintScalParam(m->rp,     "rp",     "[ ]",    scal, title, &print_title);		
 		if(frSoftID != -1) PetscPrintf(PETSC_COMM_WORLD, "frSoftID = %lld ", (LLD)frSoftID);
 		if(chSoftID != -1) PetscPrintf(PETSC_COMM_WORLD, "chSoftID = %lld ", (LLD)chSoftID);
@@ -776,7 +781,8 @@ PetscErrorCode DBMatReadPhase(DBMat *dbm, FB *fb, PetscBool PrintOutput)
 	m->fr     /= scal->angle;      
 
 	m->eta_st /= scal->viscosity;
-    
+	m->eta_vp /= scal->viscosity;
+	
 	// temperature
 	m->alpha  /= scal->expansivity;
 	m->Cp     /= scal->cpecific_heat;
@@ -1645,7 +1651,7 @@ PetscErrorCode PrintMatProp(Material_t *MatProp)
 	PetscPrintf(PETSC_COMM_WORLD,">>> dc Cr.:           Bdc   = %1.7e,  Edc   = %1.7e,    Rdc   = %1.7e,    mu  = %1.7e \n", MatProp->Bdc, MatProp->Edc, MatProp->Rdc, MatProp->mu);
     PetscPrintf(PETSC_COMM_WORLD,">>> ps Cr.:           Bps   = %1.7e,  Eps   = %1.7e,    d     = %1.7e,    \n", MatProp->Bps, MatProp->Eps, MatProp->d);
     
-    PetscPrintf(PETSC_COMM_WORLD,">>> Plasticity:       fr    = %1.7e,  ch    = %1.7e,    eta_st= %1.7e,    rp= %1.7e,    frSoftID = %i,  chSoftID = %i,   healID = %i \n", MatProp->fr, MatProp->ch, MatProp->eta_st, MatProp->rp, MatProp->frSoftID, MatProp->chSoftID, MatProp->healID);
+    PetscPrintf(PETSC_COMM_WORLD,">>> Plasticity:       fr    = %1.7e,  ch    = %1.7e,    eta_vp= %1.7e,    eta_st= %1.7e, rp= %1.7e,    frSoftID = %i,  chSoftID = %i,   healID = %i \n", MatProp->fr, MatProp->ch, MatProp->eta_st, MatProp->eta_vp, MatProp->rp, MatProp->frSoftID, MatProp->chSoftID, MatProp->healID);
 	PetscPrintf(PETSC_COMM_WORLD,">>> Thermal:          alpha = %1.7e,  Cp    = %1.7e,    k     = %1.7e,    A = %1.7e,    T        = %1.7e \n", MatProp->alpha, MatProp->Cp, MatProp->k, MatProp->A, MatProp->T);
 	PetscPrintf(PETSC_COMM_WORLD,"          			nu_k  = %1.7e,  T_Nu  = %1.7e,   \n", MatProp->nu_k, MatProp->T_Nu);
 	PetscPrintf(PETSC_COMM_WORLD,"          			T_sol = %1.7e, T_liq  = %1.7e,   Latent_hx= %1.7e,    \n", MatProp->T_sol, MatProp->T_liq, MatProp->Latent_hx);

--- a/src/phase.cpp
+++ b/src/phase.cpp
@@ -510,8 +510,8 @@ PetscErrorCode DBMatReadPhase(DBMat *dbm, FB *fb, PetscBool PrintOutput)
 	}
 
 
-	m->eta_st   = eta_st;
-	m->eta_vp   = eta_vp;
+	m->eta_st = eta_st;
+	m->eta_vp = eta_vp;
 	
 	// set softening law IDs
 	m->chSoftID = chSoftID;

--- a/src/phase.h
+++ b/src/phase.h
@@ -188,6 +188,7 @@ public:
 	PetscScalar  fr;                // friction angle                             [deg]
 	PetscScalar  ch;                // cohesion
 	PetscScalar  eta_st;            // stabilization viscosity
+	PetscScalar  eta_vp;            // viscoplastic viscosity
 	PetscScalar  rp;                // ratio of pore pressure to overburden stress
 	PetscInt     frSoftID;          // friction softening law ID (-1 if not defined)
 	PetscInt     chSoftID;          // cohesion softening law ID (-1 if not defined)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,7 +331,7 @@ end
     ParamFile = "test_9_FallingBlock_PhaseDiagrams.dat";
     
     keywords = ("|Div|_inf","|Div|_2","|mRes|_2")
-    acc      = ((rtol=1e-7,atol=1e-11), (rtol=1e-6, atol=1e-11), (rtol=2e-6,atol=1e-9));
+    acc      = ((rtol=1e-7,atol=1e-11), (rtol=1e-6, atol=1e-11), (rtol=2e-5,atol=1e-8));
     
     # Perform tests
     @test perform_lamem_test(dir,ParamFile,"test_9_FallingBlock_PhaseDiagrams.expected",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -150,6 +150,13 @@ end
     @test perform_lamem_test(dir,"localization.dat","Loc1_c_Direct_VEP_opt-p1.expected",
                             args="-nstep_max 20", 
                             keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec)
+
+
+    # t4_Loc1_d_MUMPS_VEP_VPReg_opt
+    @test perform_lamem_test(dir,"localization_eta_vp_reg.dat","t4_Loc1_d_MUMPS_VEP_VPReg_opt-p1.expected",
+                            args="-nstep_max 20", 
+                            keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec)
+
 end
 
 @testset "t5_Permeability" begin

--- a/test/t4_Loc/CompareStabilizations.jl
+++ b/test/t4_Loc/CompareStabilizations.jl
@@ -1,0 +1,82 @@
+# Small routine to compare different plasticity stabilizations in LaMEM, namely:
+# 1. No stabilization
+# 2. Using the stabilization viscosity per phase (which uses a minimum viscosity per phase)
+# 3. Using the viscoplastic regularisation by Duretz et al, which adds a term to the yield stress  (tau_y = tau_y + 2*eta_vp*DIIpl)
+
+# perform runs on the command-line with:
+# 1. No stabilization
+# ../../bin/opt/LaMEM -ParamFile localization_eta_vp_reg.dat -nel_x 128 -nel_z 64 -eta_vp[1] 1e18 >> no_regularisation.log
+
+# 2. eta_st regularisation (minimum viscosity per phase)
+# ../../bin/opt/LaMEM -ParamFile localization_eta_vp_reg.dat -nel_x 128 -nel_z 64 -eta_vp[1] 1e18 -eta_st[1] 1e21 -eta_st[2] 1e21 -eta_st[0] 1e20  >> regularisation_eta_st.log
+
+# 3. eta_vp regularisation (viscoplastic regularisation)
+# ../../bin/opt/LaMEM -ParamFile localization_eta_vp_reg.dat -nel_x 128 -nel_z 64 -eta_vp[0] 1e21 -eta_vp[1] 1e21 -eta_vp[2] 1e21 >> regularisation_viscoplastic.log
+
+# 4. eta_min everywhere
+# ../../bin/opt/LaMEM -ParamFile localization_eta_vp_reg.dat -nel_x 128 -nel_z 64 -eta_vp[1] 1e18 -eta_st[1] 1e18 -eta_min 1e21 >> regularisation_eta_min.log
+
+# Timings obtained on my machine:
+# - no_regularisation.log: 392s
+# - regularisation_eta_st.log: 82s
+# - regularisation_viscoplastic.log: 57s
+
+
+#=
+
+# Now lets analyze the logfiles and plot results.
+using Makie
+
+function ReadFile(filename, keyword, type=Int64)
+    
+    f = open(filename)
+    lines = readlines(f)
+    close(f)
+    
+    idx = findall(x->occursin(keyword,x), lines)
+    values = []
+    for i in idx
+        push!(values, parse(type, split(lines[i], " ")[end]))
+    end
+
+    return @. type(values) 
+end
+
+keyword="Number of iterations    :"
+iter1 = ReadFile("no_regularisation.log",keyword)
+iter2 = ReadFile("regularisation_eta_st.log",keyword)
+iter3 = ReadFile("regularisation_viscoplastic.log",keyword)
+#iter4 = ReadFile("regularisation_eta_min.log", keyword)
+
+# Create plot
+using CairoMakie
+x = [1:length(iter1); 1:length(iter2); 1:length(iter3)]
+c = [ones(Int64,size(iter1)); ones(Int64,size(iter2))*2; ones(Int64,size(iter4))*3]
+iter = [iter1; iter2; iter3]
+
+# Create barplot with results
+colors = Makie.wong_colors()
+fig = Figure()
+ax = Axis(fig[1,1],  title = "localization_eta_vp_reg.dat", xlabel="timestep",ylabel="nonlinear iteration")
+
+barplot!(ax, x, iter, dodge = c, color = colors[c]) # plot
+labels = ["no regularisation", "eta_st 1e21", "eta_vp 1e21"]
+elements = [PolyElement(polycolor = colors[i]) for i in 1:length(labels)]
+Legend(fig[1,2], elements, labels) # Legend
+fig
+
+save("iter.png", fig, size=(2000,1000))
+
+=#
+
+
+# Next lets make a few sims with different resolutions and VP regularisation
+
+
+#../../bin/opt/LaMEM -ParamFile localization_eta_vp_reg.dat -nel_x 64   -nel_z 32 -eta_vp[0] 1e21 -eta_vp[1] 1e21 -eta_vp[2] 1e21 -out_file_name vp_reg_64   
+#../../bin/opt/LaMEM -ParamFile localization_eta_vp_reg.dat -nel_x 128 -nel_z  64 -eta_vp[0] 1e21 -eta_vp[1] 1e21 -eta_vp[2] 1e21 -out_file_name vp_reg_128   
+#../../bin/opt/LaMEM -ParamFile localization_eta_vp_reg.dat -nel_x 256 -nel_z 128 -eta_vp[0] 1e21 -eta_vp[1] 1e21 -eta_vp[2] 1e21 -out_file_name vp_reg_256   
+#../../bin/opt/LaMEM -ParamFile localization_eta_vp_reg.dat -nel_x 512 -nel_z 256 -eta_vp[0] 1e21 -eta_vp[1] 1e21 -eta_vp[2] 1e21 -out_file_name vp_reg_512   
+
+#../../bin/opt/LaMEM -ParamFile localization_eta_vp_reg.dat -nel_x 1024 -nel_z 512 -eta_vp[0] 1e21 -eta_vp[1] 1e21 -eta_vp[2] 1e21 -out_file_name vp_reg_1024 
+

--- a/test/t4_Loc/localization_eta_vp_reg.dat
+++ b/test/t4_Loc/localization_eta_vp_reg.dat
@@ -185,7 +185,7 @@
 	<MaterialStart>
 		ID         = 2      # phase id  [-]
 		rho        = 100    # density - if dimensional [kg/m3]
-		eta        = 1e19   # Viscosity - dimensional [Pa.s]
+		eta        = 1e20   # Viscosity - dimensional [Pa.s]
 		G          =  5e10
 		Kb         =  8e10
 		ch         =  50e6

--- a/test/t4_Loc/localization_eta_vp_reg.dat
+++ b/test/t4_Loc/localization_eta_vp_reg.dat
@@ -1,0 +1,225 @@
+#===============================================================================
+# Scaling
+#===============================================================================
+
+	units = geo
+
+	unit_temperature = 1.0
+	unit_length      = 1e4
+	unit_viscosity   = 1e20
+	unit_stress      = 1e8
+
+#===============================================================================
+# Time stepping parameters
+#===============================================================================
+
+	dt        = 1.5e-3 # time step
+	dt_min    = 2e-5   # minimum time step (declare divergence if lower value is attempted)
+	dt_max    = 5e-3   # maximum time step
+	inc_dt    = 0.1    # time step increment per time step (fraction of unit)
+	CFL       = 0.1    # CFL (Courant-Friedrichs-Lewy) criterion
+	CFLMAX    = 0.1    # CFL criterion for elasticity
+	time_end  = 0.2   # simulation end time
+	nstep_out = 1      # save output every n steps
+
+#===============================================================================
+# Grid & discretization parameters
+#===============================================================================
+
+# Number of cells for all segments
+
+	nel_x = 64
+	nel_y = 1
+	nel_z = 16
+
+# Coordinates of all segments (including start and end points)
+
+	coord_x = -20.0  20.0
+	coord_y =  0.0   0.625
+	coord_z =  0.0   15.0
+
+#===============================================================================
+# Free surface
+#===============================================================================
+
+# default
+
+#===============================================================================
+# Boundary conditions
+#===============================================================================
+
+# Background strain rate parameters
+
+	exx_num_periods  = 1      # number intervals of constant strain rate (x-axis)
+	exx_strain_rates = -1e-15 # strain rates for each interval
+
+# Free surface top boundary flag
+
+	open_top_bound = 1
+
+#===============================================================================
+# Jacobian & residual evaluation parameters
+#===============================================================================
+
+	gravity        = 0.0 0.0 -10.0  # gravity vector
+	FSSA           = 1.0            # free surface stabilization parameter [0 - 1]
+	init_guess     = 1              # initial guess flag
+	p_lim_plast    = 1              # limit pressure at first iteration for plasticity
+	eta_min        = 1e18           # viscosity upper bound
+	eta_max        = 1e27           # viscosity lower limit
+	eta_ref        = 1e22           # reference viscosity (initial guess)
+	min_cohes      = 1e6            # cohesion lower bound
+	min_fric       = 5.0            # friction lower bound
+	tau_ult        = 1e9            # ultimate yield stress
+	init_lith_pres = 1              # initial pressure with lithostatic pressure (stabilizes compressible setups in the first steps)
+	Compute_velocity_gradient = 1    # compute the velocity gradient tensor 1: active, 0: not active. If active, it automatically activates the output in the .pvd file
+
+#===============================================================================
+# Solver options
+#===============================================================================
+	SolverType 		=	direct 			# solver [direct or multigrid]
+	DirectSolver 	=	mumps			# mumps/superlu_dist/pastix	
+	DirectPenalty 	=	1e3
+
+
+#===============================================================================
+# Model setup & advection
+#===============================================================================
+
+	msetup         = geom              # setup type
+	nmark_x        = 5                 # markers per cell in x-direction
+	nmark_y        = 5                 # ...                 y-direction
+	nmark_z        = 5                 # ...                 z-direction
+	rand_noise     = 0                 # random noise flag
+	bg_phase       = 1                 # background phase ID
+
+	# Geometric primitives:
+
+	<LayerStart>
+		phase  = 2     # Air layer
+		top    = 15.0
+		bottom = 10.0
+	<LayerEnd>
+
+	<BoxStart>        # Weak inclusion
+		phase  = 0
+		# box bound coordinates: left, right, front, back, bottom, top
+		bounds = -0.5 0.5   0.0 1.0   0.0 1.0
+	<BoxEnd>
+
+#===============================================================================
+# Output
+#===============================================================================
+
+# Grid output options (output is always active)
+
+	out_file_name       = test_vep_analytical # output file name
+	out_pvd             = 1                   # activate writing .pvd file
+	out_phase           = 1
+	out_density         = 1
+	out_visc_total      = 1
+	out_velocity        = 1
+	out_pressure        = 1
+	out_dev_stress      = 1
+	out_j2_dev_stress   = 1
+	out_strain_rate     = 1
+	out_j2_strain_rate  = 1
+	out_plast_strain    = 1
+	out_plast_dissip    = 1
+	out_moment_res      = 1
+	out_cont_res        = 1
+	out_yield           = 1
+
+# AVD phase viewer output options (requires activation)
+
+	out_avd     = 1 # activate AVD phase output
+	out_avd_pvd = 1 # activate writing .pvd file
+	out_avd_ref = 1 # AVD grid refinement factor
+
+#===============================================================================
+# Material phase parameters
+#===============================================================================
+
+	# Strain softening parameters
+	<SofteningStart>
+		ID   = 0
+		A    = 0.25
+		APS1 = 0.00001
+		APS2 = 0.01
+	<SofteningEnd>
+
+
+	# Inclusion
+	<MaterialStart>
+		ID         = 0     # phase id  [-]
+		rho        = 2700  # density - if dimensional [kg/m3]
+		eta        = 1e21  # Viscosity - dimensional [Pa.s]
+		G          =  5e10
+		Kb         =  8e10
+		ch         =  50e6
+		fr         =  30
+		frSoftID   =  0    # softening ID
+		chSoftID   =  0
+		eta_vp    =  1e21
+
+	<MaterialEnd>
+
+
+	# Matrix
+	<MaterialStart>
+		ID        =  1    # phase id  [-]
+		rho       =  2700 # density - if dimensional [kg/m3]
+		eta       =  1e24 # Viscosity - dimensional [Pa.s]
+		G         =  5e10
+		Kb        =  8e10
+		ch        =  50e6
+		fr        =  30
+		frSoftID  =  0     # softening ID
+		chSoftID  =  0
+		eta_vp    =  1e21
+		#eta_st    =  1e21
+		
+	<MaterialEnd>
+
+	# sticky-air layer
+	<MaterialStart>
+		ID         = 2      # phase id  [-]
+		rho        = 100    # density - if dimensional [kg/m3]
+		eta        = 1e19   # Viscosity - dimensional [Pa.s]
+		G          =  5e10
+		Kb         =  8e10
+		ch         =  50e6
+		fr         =  30
+		frSoftID   =  0     # softening ID
+		chSoftID   =  0
+	<MaterialEnd>
+
+#===============================================================================
+# PETSc options
+#===============================================================================
+<PetscOptionsStart>
+	
+	# Eisenstatt-Walker (sometimes converges faster for nonlinear cases)
+	-snes_ksp_ew
+    -snes_ksp_ew_rtolmax 1e-1
+    -snes_max_linear_solve_fail 10000
+ 	-snes_max_it 			100
+	
+	-pcmat_pgamma 1e2
+   		
+	# Newton/picard options
+	-snes_PicardSwitchToNewton_rtol 1e0   # relative tolerance to switch to Newton (1e-2)
+	-snes_NewtonSwitchToPicard_it  	20     # number of Newton iterations after which we switch back to Picard
+
+	# Linesearch options
+	-snes_linesearch_type 		l2 				#Linesearch type (one of) shell basic l2 bt cp (SNESLineSearchSetType) 
+	-snes_linesearch_maxstep 	1.0				# very important to prevent the code from "blowing up"
+	
+	
+	# Jacobian solver
+	-js_ksp_type fgmres	
+	-js_ksp_max_it 50
+
+<PetscOptionsEnd>
+
+#===============================================================================

--- a/test/t4_Loc/localization_eta_vp_reg.dat
+++ b/test/t4_Loc/localization_eta_vp_reg.dat
@@ -176,7 +176,7 @@
 		fr        =  30
 		frSoftID  =  0     # softening ID
 		chSoftID  =  0
-		#eta_vp    =  1e21
+		eta_vp    =  1e21
 		#eta_st    =  1e21
 		
 	<MaterialEnd>

--- a/test/t4_Loc/localization_eta_vp_reg.dat
+++ b/test/t4_Loc/localization_eta_vp_reg.dat
@@ -160,7 +160,7 @@
 		fr         =  30
 		frSoftID   =  0    # softening ID
 		chSoftID   =  0
-		eta_vp    =  1e21
+	#	eta_vp    =  1e21
 
 	<MaterialEnd>
 
@@ -176,7 +176,7 @@
 		fr        =  30
 		frSoftID  =  0     # softening ID
 		chSoftID  =  0
-		eta_vp    =  1e21
+		#eta_vp    =  1e21
 		#eta_st    =  1e21
 		
 	<MaterialEnd>

--- a/test/t4_Loc/localization_eta_vp_reg.dat
+++ b/test/t4_Loc/localization_eta_vp_reg.dat
@@ -20,7 +20,7 @@
 	CFL       = 0.1    # CFL (Courant-Friedrichs-Lewy) criterion
 	CFLMAX    = 0.1    # CFL criterion for elasticity
 	time_end  = 0.2   # simulation end time
-	nstep_out = 1      # save output every n steps
+	nstep_out = 5      # save output every n steps
 
 #===============================================================================
 # Grid & discretization parameters
@@ -77,7 +77,10 @@
 #===============================================================================
 # Solver options
 #===============================================================================
+	#SolverType 		=	multigrid 			# solver [direct or multigrid]
 	SolverType 		=	direct 			# solver [direct or multigrid]
+	
+	MGLevels 		=   4
 	DirectSolver 	=	mumps			# mumps/superlu_dist/pastix	
 	DirectPenalty 	=	1e3
 
@@ -92,6 +95,12 @@
 	nmark_z        = 5                 # ...                 z-direction
 	rand_noise     = 0                 # random noise flag
 	bg_phase       = 1                 # background phase ID
+	advect         = rk2               # advection scheme
+	interp         = stagp             # velocity interpolation scheme
+	mark_ctrl      = subgrid           # marker control type
+	nmark_lim      = 8 100             # min/max number per cell
+	nmark_sub       = 1                 # max number of same phase markers per subcell (subgrid marker control)
+
 
 	# Geometric primitives:
 

--- a/test/t4_Loc/t4_Loc1_d_MUMPS_VEP_VPReg_opt-p1.expected
+++ b/test/t4_Loc/t4_Loc1_d_MUMPS_VEP_VPReg_opt-p1.expected
@@ -34,7 +34,7 @@ Time stepping parameters:
    Time step increase factor    : 0.1 
    CFL criterion                : 0.1 
    CFLMAX (fixed time steps)    : 0.1 
-   Output every [n] steps       : 1 
+   Output every [n] steps       : 5 
    Output [n] initial steps     : 1 
 --------------------------------------------------------------------------
 Grid parameters:
@@ -96,16 +96,17 @@ Solution parameters & controls:
    Ground water level type                 : none 
 --------------------------------------------------------------------------
 Advection parameters:
-   Advection scheme              : Euler 1-st order (basic implementation)
+   Advection scheme              : Runge-Kutta 2-nd order
    Periodic marker advection     : 0 0 0 
    Marker setup scheme           : geometric primitives
-   Velocity interpolation scheme : STAG (linear)
-   Marker control type           : no marker control
+   Velocity interpolation scheme : empirical STAGP (STAG + pressure points)
+   Marker control type           : subgrid 
    Markers per cell [nx, ny, nz] : [5, 5, 5] 
    Marker distribution type      : uniform
    Background phase ID           : 1 
+   Interpolation constant        : 0.666667 
 --------------------------------------------------------------------------
-Reading geometric primitives ... done (0.000944 sec)
+Reading geometric primitives ... done (0.000985 sec)
 --------------------------------------------------------------------------
 Output parameters:
    Output file name                        : test_vep_analytical 
@@ -140,7 +141,7 @@ Solver parameters specified:
    Solver type                   : serial direct/lu 
    Solver package                : petsc 
 --------------------------------------------------------------------------
-Initializing pressure with lithostatic pressure ... done (0.000253 sec)
+Initializing pressure with lithostatic pressure ... done (0.000262 sec)
 --------------------------------------------------------------------------
 ============================== INITIAL GUESS =============================
 --------------------------------------------------------------------------
@@ -154,7 +155,7 @@ Initializing pressure with lithostatic pressure ... done (0.000253 sec)
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 2
-SNES solution time      : 0.015477 (sec)
+SNES solution time      : 0.015817 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
@@ -163,7 +164,7 @@ Residual summary:
    Momentum: 
       |mRes|_2  = 2.581413713634e-07 
 --------------------------------------------------------------------------
-Saving output ... done (0.048228 sec)
+Saving output ... done (0.052931 sec)
 --------------------------------------------------------------------------
 ================================= STEP 1 =================================
 --------------------------------------------------------------------------
@@ -180,7 +181,7 @@ Tentative time step : 0.00150000 [Myr]
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016657 (sec)
+SNES solution time      : 0.017386 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
@@ -191,356 +192,52 @@ Residual summary:
 --------------------------------------------------------------------------
 Actual time step : 0.00150 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.054367 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2200e-03 s
+--------------------------------------------------------------------------
+Saving output ... done (0.050447 sec)
 --------------------------------------------------------------------------
 ================================= STEP 2 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00150000 [Myr] 
 Tentative time step : 0.00165000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 1.848643372433e+00 
+  0 SNES Function norm 1.848649079226e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.358737257691e-03 
-  1 MMFD   ||F||/||F0||=1.275929e-03 
+  1 SNES Function norm 2.358739533649e-03 
+  1 MMFD   ||F||/||F0||=1.275926e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.126410787629e-08 
+  2 SNES Function norm 1.178128428405e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017674 (sec)
+SNES solution time      : 0.01749 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 1.708728112859e-09 
-      |Div|_2   = 2.493258278823e-09 
+      |Div|_inf = 1.710931932616e-09 
+      |Div|_2   = 2.495831088499e-09 
    Momentum: 
-      |mRes|_2  = 1.098470706954e-08 
+      |mRes|_2  = 1.151388234087e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00165 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.049236 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.3980e-03 s
 --------------------------------------------------------------------------
 ================================= STEP 3 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00315000 [Myr] 
 Tentative time step : 0.00181500 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 2.114715781027e+00 
+  0 SNES Function norm 2.114718827807e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.577977248031e-03 
-  1 MMFD   ||F||/||F0||=1.219066e-03 
+  1 SNES Function norm 2.577984395597e-03 
+  1 MMFD   ||F||/||F0||=1.219067e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.354120920390e-08 
---------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < atol 
-Number of iterations    : 2
-SNES solution time      : 0.016602 (sec)
---------------------------------------------------------------------------
-Residual summary: 
-   Continuity: 
-      |Div|_inf = 1.954759254964e-09 
-      |Div|_2   = 2.847197109891e-09 
-   Momentum: 
-      |mRes|_2  = 1.323849747219e-08 
---------------------------------------------------------------------------
-Actual time step : 0.00182 [Myr] 
---------------------------------------------------------------------------
-Saving output ... done (0.048873 sec)
---------------------------------------------------------------------------
-================================= STEP 4 =================================
---------------------------------------------------------------------------
-Current time        : 0.00496500 [Myr] 
-Tentative time step : 0.00199650 [Myr] 
---------------------------------------------------------------------------
-  0 SNES Function norm 2.420238878210e+00 
-  0 PICARD ||F||/||F0||=1.000000e+00 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.821582397465e-03 
-  1 MMFD   ||F||/||F0||=1.165828e-03 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.528281437796e-08 
---------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < atol 
-Number of iterations    : 2
-SNES solution time      : 0.016817 (sec)
---------------------------------------------------------------------------
-Residual summary: 
-   Continuity: 
-      |Div|_inf = 2.207595058837e-09 
-      |Div|_2   = 3.215200481294e-09 
-   Momentum: 
-      |mRes|_2  = 1.494077980482e-08 
---------------------------------------------------------------------------
-Actual time step : 0.00200 [Myr] 
---------------------------------------------------------------------------
-Saving output ... done (0.048174 sec)
---------------------------------------------------------------------------
-================================= STEP 5 =================================
---------------------------------------------------------------------------
-Current time        : 0.00696150 [Myr] 
-Tentative time step : 0.00219615 [Myr] 
---------------------------------------------------------------------------
-  0 SNES Function norm 2.751142620603e+00 
-  0 PICARD ||F||/||F0||=1.000000e+00 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 3.090663890363e-03 
-  1 MMFD   ||F||/||F0||=1.123411e-03 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.811313689886e-08 
---------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < atol 
-Number of iterations    : 2
-SNES solution time      : 0.016861 (sec)
---------------------------------------------------------------------------
-Residual summary: 
-   Continuity: 
-      |Div|_inf = 2.474455116929e-09 
-      |Div|_2   = 3.602433565129e-09 
-   Momentum: 
-      |mRes|_2  = 1.775128729770e-08 
---------------------------------------------------------------------------
-Actual time step : 0.00220 [Myr] 
---------------------------------------------------------------------------
-Saving output ... done (0.048225 sec)
---------------------------------------------------------------------------
-================================= STEP 6 =================================
---------------------------------------------------------------------------
-Current time        : 0.00915765 [Myr] 
-Tentative time step : 0.00241577 [Myr] 
---------------------------------------------------------------------------
-  0 SNES Function norm 3.090912363716e+00 
-  0 PICARD ||F||/||F0||=1.000000e+00 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 3.386932694568e-03 
-  1 MMFD   ||F||/||F0||=1.095771e-03 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 2.145019811302e-08 
---------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < atol 
-Number of iterations    : 2
-SNES solution time      : 0.016697 (sec)
---------------------------------------------------------------------------
-Residual summary: 
-   Continuity: 
-      |Div|_inf = 2.727370357288e-09 
-      |Div|_2   = 3.968722660280e-09 
-   Momentum: 
-      |mRes|_2  = 2.107985387838e-08 
---------------------------------------------------------------------------
-Actual time step : 0.00242 [Myr] 
---------------------------------------------------------------------------
-Saving output ... done (0.051222 sec)
---------------------------------------------------------------------------
-================================= STEP 7 =================================
---------------------------------------------------------------------------
-Current time        : 0.01157342 [Myr] 
-Tentative time step : 0.00265734 [Myr] 
---------------------------------------------------------------------------
-  0 SNES Function norm 3.462093481515e+00 
-  0 PICARD ||F||/||F0||=1.000000e+00 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 3.712466582960e-03 
-  1 MMFD   ||F||/||F0||=1.072318e-03 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 2.434522460982e-08 
---------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < atol 
-Number of iterations    : 2
-SNES solution time      : 0.016666 (sec)
---------------------------------------------------------------------------
-Residual summary: 
-   Continuity: 
-      |Div|_inf = 3.016411207275e-09 
-      |Div|_2   = 4.386892746951e-09 
-   Momentum: 
-      |mRes|_2  = 2.394671445792e-08 
---------------------------------------------------------------------------
-Actual time step : 0.00266 [Myr] 
---------------------------------------------------------------------------
-Saving output ... done (0.049847 sec)
---------------------------------------------------------------------------
-================================= STEP 8 =================================
---------------------------------------------------------------------------
-Current time        : 0.01423076 [Myr] 
-Tentative time step : 0.00292308 [Myr] 
---------------------------------------------------------------------------
-  0 SNES Function norm 3.843455175315e+00 
-  0 PICARD ||F||/||F0||=1.000000e+00 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 4.069624129361e-03 
-  1 MMFD   ||F||/||F0||=1.058845e-03 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 2.772056877361e-08 
---------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < atol 
-Number of iterations    : 2
-SNES solution time      : 0.022857 (sec)
---------------------------------------------------------------------------
-Residual summary: 
-   Continuity: 
-      |Div|_inf = 3.320662709290e-09 
-      |Div|_2   = 4.825540080873e-09 
-   Momentum: 
-      |mRes|_2  = 2.729732763588e-08 
---------------------------------------------------------------------------
-Actual time step : 0.00292 [Myr] 
---------------------------------------------------------------------------
-Saving output ... done (0.053924 sec)
---------------------------------------------------------------------------
-================================= STEP 9 =================================
---------------------------------------------------------------------------
-Current time        : 0.01715383 [Myr] 
-Tentative time step : 0.00321538 [Myr] 
---------------------------------------------------------------------------
-  0 SNES Function norm 4.242580263917e+00 
-  0 PICARD ||F||/||F0||=1.000000e+00 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 4.461023226090e-03 
-  1 MMFD   ||F||/||F0||=1.051488e-03 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 3.059107835171e-08 
---------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < atol 
-Number of iterations    : 2
-SNES solution time      : 0.017796 (sec)
---------------------------------------------------------------------------
-Residual summary: 
-   Continuity: 
-      |Div|_inf = 3.648009267067e-09 
-      |Div|_2   = 5.295169111710e-09 
-   Momentum: 
-      |mRes|_2  = 3.012930896650e-08 
---------------------------------------------------------------------------
-Actual time step : 0.00322 [Myr] 
---------------------------------------------------------------------------
-Saving output ... done (0.050454 sec)
---------------------------------------------------------------------------
-================================ STEP 10 =================================
---------------------------------------------------------------------------
-Current time        : 0.02036922 [Myr] 
-Tentative time step : 0.00353692 [Myr] 
---------------------------------------------------------------------------
-  0 SNES Function norm 4.693854994103e+00 
-  0 PICARD ||F||/||F0||=1.000000e+00 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 4.889513115823e-03 
-  1 MMFD   ||F||/||F0||=1.041684e-03 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 3.572752165451e-08 
---------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < atol 
-Number of iterations    : 2
-SNES solution time      : 0.016902 (sec)
---------------------------------------------------------------------------
-Residual summary: 
-   Continuity: 
-      |Div|_inf = 3.950573394523e-09 
-      |Div|_2   = 5.734518184238e-09 
-   Momentum: 
-      |mRes|_2  = 3.526430354860e-08 
---------------------------------------------------------------------------
-Actual time step : 0.00354 [Myr] 
---------------------------------------------------------------------------
-Saving output ... done (0.05107 sec)
---------------------------------------------------------------------------
-================================ STEP 11 =================================
---------------------------------------------------------------------------
-Current time        : 0.02390614 [Myr] 
-Tentative time step : 0.00389061 [Myr] 
---------------------------------------------------------------------------
-  0 SNES Function norm 5.157382781116e+00 
-  0 PICARD ||F||/||F0||=1.000000e+00 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 5.358198397633e-03 
-  1 MMFD   ||F||/||F0||=1.038938e-03 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 4.059082540686e-08 
---------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < atol 
-Number of iterations    : 2
-SNES solution time      : 0.016742 (sec)
---------------------------------------------------------------------------
-Residual summary: 
-   Continuity: 
-      |Div|_inf = 4.277244732130e-09 
-      |Div|_2   = 6.204876136013e-09 
-   Momentum: 
-      |mRes|_2  = 4.011377094399e-08 
---------------------------------------------------------------------------
-Actual time step : 0.00389 [Myr] 
---------------------------------------------------------------------------
-Saving output ... done (0.050129 sec)
---------------------------------------------------------------------------
-================================ STEP 12 =================================
---------------------------------------------------------------------------
-Current time        : 0.02779675 [Myr] 
-Tentative time step : 0.00427968 [Myr] 
---------------------------------------------------------------------------
-  0 SNES Function norm 5.664149883613e+00 
-  0 PICARD ||F||/||F0||=1.000000e+00 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 5.870390413502e-03 
-  1 MMFD   ||F||/||F0||=1.036412e-03 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 4.626906857690e-08 
---------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < atol 
-Number of iterations    : 2
-SNES solution time      : 0.017135 (sec)
---------------------------------------------------------------------------
-Residual summary: 
-   Continuity: 
-      |Div|_inf = 4.617797686426e-09 
-      |Div|_2   = 6.693802229275e-09 
-   Momentum: 
-      |mRes|_2  = 4.578230792227e-08 
---------------------------------------------------------------------------
-Actual time step : 0.00428 [Myr] 
---------------------------------------------------------------------------
-Saving output ... done (0.04854 sec)
---------------------------------------------------------------------------
-================================ STEP 13 =================================
---------------------------------------------------------------------------
-Current time        : 0.03207643 [Myr] 
-Tentative time step : 0.00470764 [Myr] 
---------------------------------------------------------------------------
-  0 SNES Function norm 6.213066205891e+00 
-  0 PICARD ||F||/||F0||=1.000000e+00 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 6.429633724356e-03 
-  1 MMFD   ||F||/||F0||=1.034857e-03 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 5.638614028281e-08 
---------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < atol 
-Number of iterations    : 2
-SNES solution time      : 0.016785 (sec)
---------------------------------------------------------------------------
-Residual summary: 
-   Continuity: 
-      |Div|_inf = 4.944908750999e-09 
-      |Div|_2   = 7.165378161867e-09 
-   Momentum: 
-      |mRes|_2  = 5.592901010916e-08 
---------------------------------------------------------------------------
-Actual time step : 0.00471 [Myr] 
---------------------------------------------------------------------------
-Saving output ... done (0.049414 sec)
---------------------------------------------------------------------------
-================================ STEP 14 =================================
---------------------------------------------------------------------------
-Current time        : 0.03678407 [Myr] 
-Tentative time step : 0.00500000 [Myr] 
---------------------------------------------------------------------------
-  0 SNES Function norm 6.715781328482e+00 
-  0 PICARD ||F||/||F0||=1.000000e+00 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 6.795637914085e-03 
-  1 MMFD   ||F||/||F0||=1.011891e-03 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 6.343216796546e-08 
+  2 SNES Function norm 1.327385661256e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
@@ -548,211 +245,545 @@ SNES solution time      : 0.017128 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 5.163490047917e-09 
-      |Div|_2   = 7.477987598987e-09 
+      |Div|_inf = 1.953894243424e-09 
+      |Div|_2   = 2.845965192590e-09 
    Momentum: 
-      |mRes|_2  = 6.298983754756e-08 
+      |mRes|_2  = 1.296517456471e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00182 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2670e-03 s
+--------------------------------------------------------------------------
+================================= STEP 4 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00496500 [Myr] 
+Tentative time step : 0.00199650 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.420242367766e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.821589529929e-03 
+  1 MMFD   ||F||/||F0||=1.165829e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 1.572744397147e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.017 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.207158488896e-09 
+      |Div|_2   = 3.214934160633e-09 
+   Momentum: 
+      |mRes|_2  = 1.539534644685e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.3110e-03 s
+--------------------------------------------------------------------------
+================================= STEP 5 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00696150 [Myr] 
+Tentative time step : 0.00219615 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.751139893726e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.090670144965e-03 
+  1 MMFD   ||F||/||F0||=1.123414e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 1.889041421836e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.017158 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.471803989803e-09 
+      |Div|_2   = 3.599200526754e-09 
+   Momentum: 
+      |mRes|_2  = 1.854436585352e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00220 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1960e-03 s
+--------------------------------------------------------------------------
+Saving output ... done (0.04938 sec)
+--------------------------------------------------------------------------
+================================= STEP 6 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00915765 [Myr] 
+Tentative time step : 0.00241577 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.090915482106e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.386939595547e-03 
+  1 MMFD   ||F||/||F0||=1.095772e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 2.059524252045e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016567 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.738492677790e-09 
+      |Div|_2   = 3.982766170163e-09 
+   Momentum: 
+      |mRes|_2  = 2.020647391581e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00242 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1870e-03 s
+--------------------------------------------------------------------------
+================================= STEP 7 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01157342 [Myr] 
+Tentative time step : 0.00265734 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.462091803012e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.712474024620e-03 
+  1 MMFD   ||F||/||F0||=1.072321e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 2.450306895193e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016921 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.023714064009e-09 
+      |Div|_2   = 4.396283454136e-09 
+   Momentum: 
+      |mRes|_2  = 2.410545747033e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00266 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2940e-03 s
+--------------------------------------------------------------------------
+================================= STEP 8 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01423076 [Myr] 
+Tentative time step : 0.00292308 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.843453837455e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.069632368221e-03 
+  1 MMFD   ||F||/||F0||=1.058848e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 2.723599969895e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.01694 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.317078528118e-09 
+      |Div|_2   = 4.820730711401e-09 
+   Momentum: 
+      |mRes|_2  = 2.680597386795e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00292 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2050e-03 s
+--------------------------------------------------------------------------
+================================= STEP 9 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01715383 [Myr] 
+Tentative time step : 0.00321538 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.242576104052e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.461032330302e-03 
+  1 MMFD   ||F||/||F0||=1.051491e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 3.140446928053e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016971 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.635257079973e-09 
+      |Div|_2   = 5.278576258604e-09 
+   Momentum: 
+      |mRes|_2  = 3.095766986505e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00322 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2650e-03 s
+--------------------------------------------------------------------------
+================================ STEP 10 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02036922 [Myr] 
+Tentative time step : 0.00353692 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.693850651084e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.889523310692e-03 
+  1 MMFD   ||F||/||F0||=1.041687e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 3.630158729596e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.017259 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.950294001328e-09 
+      |Div|_2   = 5.733962451262e-09 
+   Momentum: 
+      |mRes|_2  = 3.584587723593e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00354 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2930e-03 s
+--------------------------------------------------------------------------
+Saving output ... done (0.049568 sec)
+--------------------------------------------------------------------------
+================================ STEP 11 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02390614 [Myr] 
+Tentative time step : 0.00389061 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.157375600543e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.358209904616e-03 
+  1 MMFD   ||F||/||F0||=1.038941e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 4.197440878059e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016855 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.271330743455e-09 
+      |Div|_2   = 6.196961540432e-09 
+   Momentum: 
+      |mRes|_2  = 4.151443917658e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00389 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1280e-03 s
+--------------------------------------------------------------------------
+================================ STEP 12 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02779675 [Myr] 
+Tentative time step : 0.00427968 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.664134313290e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.870402715891e-03 
+  1 MMFD   ||F||/||F0||=1.036417e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 4.709751921197e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.01711 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.608713767074e-09 
+      |Div|_2   = 6.682013145804e-09 
+   Momentum: 
+      |mRes|_2  = 4.662110054730e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00428 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1860e-03 s
+--------------------------------------------------------------------------
+================================ STEP 13 =================================
+--------------------------------------------------------------------------
+Current time        : 0.03207643 [Myr] 
+Tentative time step : 0.00470764 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.213056241530e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 6.429647609026e-03 
+  1 MMFD   ||F||/||F0||=1.034861e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 5.481987684780e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.017115 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.956072265661e-09 
+      |Div|_2   = 7.180187580114e-09 
+   Momentum: 
+      |mRes|_2  = 5.434762003917e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00471 [Myr] 
+--------------------------------------------------------------------------
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1800e-03 s
+--------------------------------------------------------------------------
+================================ STEP 14 =================================
+--------------------------------------------------------------------------
+Current time        : 0.03678407 [Myr] 
+Tentative time step : 0.00500000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.715759172251e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 6.795653423084e-03 
+  1 MMFD   ||F||/||F0||=1.011897e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 6.505604947780e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.017031 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.153297681036e-09 
+      |Div|_2   = 7.464527251906e-09 
+   Momentum: 
+      |mRes|_2  = 6.462639094490e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.053347 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1840e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 15 =================================
 --------------------------------------------------------------------------
 Current time        : 0.04178407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.824866260108e+00 
+  0 SNES Function norm 5.824801425382e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.348262008769e+00 
-  1 MMFD   ||F||/||F0||=4.031444e-01 
+  1 SNES Function norm 2.348246737641e+00 
+  1 MMFD   ||F||/||F0||=4.031462e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 6.976001417257e-01 
-  2 MMFD   ||F||/||F0||=1.197624e-01 
+  2 SNES Function norm 6.976287463720e-01 
+  2 MMFD   ||F||/||F0||=1.197687e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  3 SNES Function norm 7.125080072726e-05 
+  3 SNES Function norm 7.124482597394e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 3
-SNES solution time      : 0.024789 (sec)
+SNES solution time      : 0.024786 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 7.806479776527e-07 
-      |Div|_2   = 3.586631235413e-06 
+      |Div|_inf = 7.807299759453e-07 
+      |Div|_2   = 3.586559269188e-06 
    Momentum: 
-      |mRes|_2  = 7.116047133526e-05 
+      |mRes|_2  = 7.115449262461e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.049134 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.3020e-03 s
+--------------------------------------------------------------------------
+Saving output ... done (0.048664 sec)
 --------------------------------------------------------------------------
 ================================ STEP 16 =================================
 --------------------------------------------------------------------------
 Current time        : 0.04678407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.556351475854e+00 
+  0 SNES Function norm 6.556322528849e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 5.007714285979e-01 
-  1 MMFD   ||F||/||F0||=7.637959e-02 
+  1 SNES Function norm 5.008077097596e-01 
+  1 MMFD   ||F||/||F0||=7.638546e-02 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 5.925204769458e-03 
-  2 MMFD   ||F||/||F0||=9.037351e-04 
+  2 SNES Function norm 5.925350117790e-03 
+  2 MMFD   ||F||/||F0||=9.037612e-04 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  3 SNES Function norm 2.608877515668e-06 
+  3 SNES Function norm 2.609196102131e-06 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 3
-SNES solution time      : 0.033557 (sec)
+SNES solution time      : 0.036927 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 5.040525843032e-09 
-      |Div|_2   = 1.474069707241e-08 
+      |Div|_inf = 5.033833483324e-09 
+      |Div|_2   = 1.472903989208e-08 
    Momentum: 
-      |mRes|_2  = 2.608835871344e-06 
+      |mRes|_2  = 2.609154528724e-06 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.049379 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2340e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 17 =================================
 --------------------------------------------------------------------------
 Current time        : 0.05178407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.735443334513e+00 
+  0 SNES Function norm 5.735628837832e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 1.848773608815e+00 
-  1 MMFD   ||F||/||F0||=3.223419e-01 
+  1 SNES Function norm 1.848828983807e+00 
+  1 MMFD   ||F||/||F0||=3.223411e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 6.910822060079e-01 
-  2 MMFD   ||F||/||F0||=1.204932e-01 
+  2 SNES Function norm 6.911709034965e-01 
+  2 MMFD   ||F||/||F0||=1.205048e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  3 SNES Function norm 1.033291159407e-02 
-  3 MMFD   ||F||/||F0||=1.801589e-03 
+  3 SNES Function norm 1.033383316118e-02 
+  3 MMFD   ||F||/||F0||=1.801691e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  4 SNES Function norm 6.159741865363e-06 
+  4 SNES Function norm 6.172344179005e-06 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 4
-SNES solution time      : 0.04554 (sec)
+SNES solution time      : 0.042438 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 8.143740718834e-11 
-      |Div|_2   = 2.538393297766e-10 
+      |Div|_inf = 8.554864318917e-11 
+      |Div|_2   = 2.621203706221e-10 
    Momentum: 
-      |mRes|_2  = 6.159741860133e-06 
+      |mRes|_2  = 6.172344173440e-06 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.049239 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.4070e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 18 =================================
 --------------------------------------------------------------------------
 Current time        : 0.05678407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.245546574406e+00 
+  0 SNES Function norm 6.245465109445e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 6.778625564053e-01 
-  1 MMFD   ||F||/||F0||=1.085353e-01 
+  1 SNES Function norm 6.778755053808e-01 
+  1 MMFD   ||F||/||F0||=1.085388e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 1.653095012918e-02 
-  2 MMFD   ||F||/||F0||=2.646838e-03 
+  2 SNES Function norm 1.653426031131e-02 
+  2 MMFD   ||F||/||F0||=2.647403e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  3 SNES Function norm 2.813956058603e-05 
+  3 SNES Function norm 2.831492269092e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 3
-SNES solution time      : 0.034758 (sec)
+SNES solution time      : 0.03664 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.047125586657e-08 
-      |Div|_2   = 3.839041494174e-08 
+      |Div|_inf = 2.023878483550e-08 
+      |Div|_2   = 3.783486966760e-08 
    Momentum: 
-      |mRes|_2  = 2.813953439826e-05 
+      |mRes|_2  = 2.831489741312e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.051152 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1790e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 19 =================================
 --------------------------------------------------------------------------
 Current time        : 0.06178407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.987602508715e+00 
+  0 SNES Function norm 5.987769087126e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 1.457960213160e+00 
-  1 MMFD   ||F||/||F0||=2.434965e-01 
+  1 SNES Function norm 1.457925884897e+00 
+  1 MMFD   ||F||/||F0||=2.434840e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 6.731792865416e-01 
-  2 MMFD   ||F||/||F0||=1.124289e-01 
+  2 SNES Function norm 6.734023299299e-01 
+  2 MMFD   ||F||/||F0||=1.124630e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  3 SNES Function norm 1.910378598508e-02 
-  3 MMFD   ||F||/||F0||=3.190557e-03 
+  3 SNES Function norm 1.912501027817e-02 
+  3 MMFD   ||F||/||F0||=3.194013e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  4 SNES Function norm 4.220935644539e-05 
+  4 SNES Function norm 4.228875320225e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 4
-SNES solution time      : 0.045069 (sec)
+SNES solution time      : 0.044421 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 7.654155103638e-09 
-      |Div|_2   = 2.306079649726e-08 
+      |Div|_inf = 7.662728549459e-09 
+      |Div|_2   = 2.309216207531e-08 
    Momentum: 
-      |mRes|_2  = 4.220935014583e-05 
+      |mRes|_2  = 4.228874689741e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.051015 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1890e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 20 =================================
 --------------------------------------------------------------------------
 Current time        : 0.06678407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.937140980857e+00 
+  0 SNES Function norm 5.936958206227e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 9.609291051357e-01 
-  1 MMFD   ||F||/||F0||=1.618505e-01 
+  1 SNES Function norm 9.609628867518e-01 
+  1 MMFD   ||F||/||F0||=1.618612e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 4.591478766526e-01 
-  2 MMFD   ||F||/||F0||=7.733484e-02 
+  2 SNES Function norm 4.592122905002e-01 
+  2 MMFD   ||F||/||F0||=7.734808e-02 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  3 SNES Function norm 2.241609467967e-02 
-  3 MMFD   ||F||/||F0||=3.775571e-03 
+  3 SNES Function norm 2.241703226847e-02 
+  3 MMFD   ||F||/||F0||=3.775845e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  4 SNES Function norm 9.314883787513e-05 
+  4 SNES Function norm 9.313852809086e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 4
-SNES solution time      : 0.050542 (sec)
+SNES solution time      : 0.049564 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 8.313036506122e-08 
-      |Div|_2   = 1.492936179555e-07 
+      |Div|_inf = 8.319392843060e-08 
+      |Div|_2   = 1.494185102077e-07 
    Momentum: 
-      |mRes|_2  = 9.314871823542e-05 
+      |mRes|_2  = 9.313840823764e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.049688 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.0990e-03 s
+--------------------------------------------------------------------------
+Saving output ... done (0.047289 sec)
 --------------------------------------------------------------------------
 =========================== SOLUTION IS DONE! ============================
 --------------------------------------------------------------------------
-Total solution time : 1.82862 (sec) 
+Total solution time : 1.32788 (sec) 
 --------------------------------------------------------------------------

--- a/test/t4_Loc/t4_Loc1_d_MUMPS_VEP_VPReg_opt-p1.expected
+++ b/test/t4_Loc/t4_Loc1_d_MUMPS_VEP_VPReg_opt-p1.expected
@@ -1,0 +1,758 @@
+-------------------------------------------------------------------------- 
+                   Lithosphere and Mantle Evolution Model                   
+     Compiled: Date: Feb 12 2024 - Time: 16:48:00 	    
+     Version : 2.1.3 
+-------------------------------------------------------------------------- 
+        STAGGERED-GRID FINITE DIFFERENCE CANONICAL IMPLEMENTATION           
+-------------------------------------------------------------------------- 
+Parsing input file : localization_eta_vp_reg.dat 
+   Adding PETSc option: -snes_ksp_ew
+   Adding PETSc option: -snes_ksp_ew_rtolmax 1e-1
+   Adding PETSc option: -snes_max_linear_solve_fail 10000
+   Adding PETSc option: -snes_max_it 100
+   Adding PETSc option: -pcmat_pgamma 1e2
+   Adding PETSc option: -snes_PicardSwitchToNewton_rtol 1e0
+   Adding PETSc option: -snes_NewtonSwitchToPicard_it 20
+   Adding PETSc option: -snes_linesearch_type l2
+   Adding PETSc option: -snes_linesearch_maxstep 1.0
+   Adding PETSc option: -js_ksp_type fgmres
+   Adding PETSc option: -js_ksp_max_it 50
+Finished parsing input file 
+--------------------------------------------------------------------------
+Scaling parameters:
+   Temperature : 1. [C/K] 
+   Length      : 10000. [m] 
+   Viscosity   : 1e+20 [Pa*s] 
+   Stress      : 1e+08 [Pa] 
+--------------------------------------------------------------------------
+Time stepping parameters:
+   Simulation end time          : 0.2 [Myr] 
+   Maximum number of steps      : 20 
+   Time step                    : 0.0015 [Myr] 
+   Minimum time step            : 2e-05 [Myr] 
+   Maximum time step            : 0.005 [Myr] 
+   Time step increase factor    : 0.1 
+   CFL criterion                : 0.1 
+   CFLMAX (fixed time steps)    : 0.1 
+   Output every [n] steps       : 1 
+   Output [n] initial steps     : 1 
+--------------------------------------------------------------------------
+Grid parameters:
+   Total number of cpu                  : 1 
+   Processor grid  [nx, ny, nz]         : [1, 1, 1]
+   Fine grid cells [nx, ny, nz]         : [64, 1, 16]
+   Number of cells                      :  1024
+   Number of faces                      :  4176
+   Maximum cell aspect ratio            :  1.50000
+   Lower coordinate bounds [bx, by, bz] : [-20., 0., 0.]
+   Upper coordinate bounds [ex, ey, ez] : [20., 0.625, 15.]
+--------------------------------------------------------------------------
+Softening laws: 
+--------------------------------------------------------------------------
+   SoftLaw [0] : A = 0.25, APS1 = 1e-05, APS2 = 0.01
+--------------------------------------------------------------------------
+Material parameters: 
+--------------------------------------------------------------------------
+- Melt factor mfc = 0.000000   Phase ID : 0   
+   (dens)   : rho = 2700. [kg/m^3]  
+   (elast)  : G = 5e+10 [Pa]  Kb = 8e+10 [Pa]  E = 1.24138e+11 [Pa]  nu = 0.241379 [ ]  Vp = 7370.28 [m/s]  Vs = 4303.31 [m/s]  
+   (diff)   : eta = 1e+21 [Pa*s]  Bd = 5e-22 [1/Pa/s]  
+   (plast)  : ch = 5e+07 [Pa]  fr = 30. [deg]  frSoftID = 0 chSoftID = 0 
+
+- Melt factor mfc = 0.000000   Phase ID : 1   
+   (dens)   : rho = 2700. [kg/m^3]  
+   (elast)  : G = 5e+10 [Pa]  Kb = 8e+10 [Pa]  E = 1.24138e+11 [Pa]  nu = 0.241379 [ ]  Vp = 7370.28 [m/s]  Vs = 4303.31 [m/s]  
+   (diff)   : eta = 1e+24 [Pa*s]  Bd = 5e-25 [1/Pa/s]  
+   (plast)  : ch = 5e+07 [Pa]  fr = 30. [deg]  eta_vp = 1e+21 [Pa*s]  frSoftID = 0 chSoftID = 0 
+
+- Melt factor mfc = 0.000000   Phase ID : 2   
+   (dens)   : rho = 100. [kg/m^3]  
+   (elast)  : G = 5e+10 [Pa]  Kb = 8e+10 [Pa]  E = 1.24138e+11 [Pa]  nu = 0.241379 [ ]  Vp = 38297.1 [m/s]  Vs = 22360.7 [m/s]  
+   (diff)   : eta = 1e+19 [Pa*s]  Bd = 5e-20 [1/Pa/s]  
+   (plast)  : ch = 5e+07 [Pa]  fr = 30. [deg]  frSoftID = 0 chSoftID = 0 
+
+--------------------------------------------------------------------------
+--------------------------------------------------------------------------
+Boundary condition parameters: 
+   No-slip boundary mask [lt rt ft bk bm tp]  : 0 0 0 0 0 0 
+   Number of x-background strain rate periods : 1 
+   Open top boundary                          @ 
+--------------------------------------------------------------------------
+Solution parameters & controls:
+   Gravity [gx, gy, gz]                    : [0., 0., -10.] [m/s^2] 
+   Surface stabilization (FSSA)            :  1. 
+   Compute initial guess                   @ 
+   Use lithostatic pressure for creep      @ 
+   Limit pressure at first iteration       @ 
+   Minimum viscosity                       : 1e+18 [Pa*s] 
+   Maximum viscosity                       : 1e+27 [Pa*s] 
+   Reference viscosity (initial guess)     : 1e+22 [Pa*s] 
+   Minimum cohesion                        : 1e+06 [Pa] 
+   Minimum friction                        : 5. [deg] 
+   Ultimate yield stress                   : 1e+09 [Pa] 
+   Max. melt fraction (viscosity, density) : 1.    
+   Rheology iteration number               : 25  
+   Rheology iteration tolerance            : 1e-06    
+   Ground water level type                 : none 
+--------------------------------------------------------------------------
+Advection parameters:
+   Advection scheme              : Euler 1-st order (basic implementation)
+   Periodic marker advection     : 0 0 0 
+   Marker setup scheme           : geometric primitives
+   Velocity interpolation scheme : STAG (linear)
+   Marker control type           : no marker control
+   Markers per cell [nx, ny, nz] : [5, 5, 5] 
+   Marker distribution type      : uniform
+   Background phase ID           : 1 
+--------------------------------------------------------------------------
+Reading geometric primitives ... done (0.000879 sec)
+--------------------------------------------------------------------------
+Output parameters:
+   Output file name                        : test_vep_analytical 
+   Write .pvd file                         : yes 
+   Phase                                   @ 
+   Density                                 @ 
+   Total effective viscosity               @ 
+   Creep effective viscosity               @ 
+   Velocity                                @ 
+   Pressure                                @ 
+   Deviatoric stress tensor                @ 
+   Deviatoric stress second invariant      @ 
+   Deviatoric strain rate tensor           @ 
+   Deviatoric strain rate second invariant @ 
+   Yield stress                            @ 
+   Accumulated Plastic Strain (APS)        @ 
+   Plastic dissipation                     @ 
+   Momentum residual                       @ 
+   Continuity residual                     @ 
+--------------------------------------------------------------------------
+AVD output parameters:
+   Write .pvd file       : yes 
+   AVD refinement factor : 1 
+--------------------------------------------------------------------------
+Preconditioner parameters: 
+   Matrix type                   : monolithic
+   Penalty parameter (pgamma)    : 1.000000e+02
+   Preconditioner type           : user-defined
+--------------------------------------------------------------------------
+Solver parameters specified: 
+   Outermost Krylov solver       : fgmres 
+   Solver type                   : serial direct/lu 
+   Solver package                : petsc 
+--------------------------------------------------------------------------
+Initializing pressure with lithostatic pressure ... done (0.000257 sec)
+--------------------------------------------------------------------------
+============================== INITIAL GUESS =============================
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.933752108544e+02 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.339923933353e-01 
+  1 MMFD   ||F||/||F0||=3.406224e-04 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 2.581413956547e-07 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 2
+SNES solution time      : 0.014419 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 9.971043786811e-12 
+      |Div|_2   = 1.119873066804e-10 
+   Momentum: 
+      |mRes|_2  = 2.581413713634e-07 
+--------------------------------------------------------------------------
+Saving output ... done (0.045754 sec)
+--------------------------------------------------------------------------
+================================= STEP 1 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00000000 [Myr] 
+Tentative time step : 0.00150000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.846888661767e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 7.090317869281e-02 
+  1 MMFD   ||F||/||F0||=1.843131e-02 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  2 SNES Function norm 2.006303773010e-05 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 2
+SNES solution time      : 0.015159 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.215949385803e-07 
+      |Div|_2   = 1.697874183247e-06 
+   Momentum: 
+      |mRes|_2  = 1.999106565988e-05 
+--------------------------------------------------------------------------
+Actual time step : 0.00150 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.047551 sec)
+--------------------------------------------------------------------------
+================================= STEP 2 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00150000 [Myr] 
+Tentative time step : 0.00165000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.851816074516e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.357632098703e-03 
+  1 MMFD   ||F||/||F0||=1.273146e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 1.131639023585e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.017975 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.708357723442e-09 
+      |Div|_2   = 2.492587803068e-09 
+   Momentum: 
+      |mRes|_2  = 1.103846429600e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00165 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.046875 sec)
+--------------------------------------------------------------------------
+================================= STEP 3 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00315000 [Myr] 
+Tentative time step : 0.00181500 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.121556478761e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.576972292346e-03 
+  1 MMFD   ||F||/||F0||=1.214661e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 1.333793447359e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016712 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.953576255400e-09 
+      |Div|_2   = 2.847670944656e-09 
+   Momentum: 
+      |mRes|_2  = 1.303039777646e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00182 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.045331 sec)
+--------------------------------------------------------------------------
+================================= STEP 4 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00496500 [Myr] 
+Tentative time step : 0.00199650 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.430905690615e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.820665443333e-03 
+  1 MMFD   ||F||/||F0||=1.160335e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 1.659828816228e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016526 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.205807441192e-09 
+      |Div|_2   = 3.214207007390e-09 
+   Momentum: 
+      |mRes|_2  = 1.628410400458e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.052048 sec)
+--------------------------------------------------------------------------
+================================= STEP 5 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00696150 [Myr] 
+Tentative time step : 0.00219615 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.763106982334e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.089867384034e-03 
+  1 MMFD   ||F||/||F0||=1.118258e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 1.772198598025e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016954 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.469519595623e-09 
+      |Div|_2   = 3.596767280624e-09 
+   Momentum: 
+      |mRes|_2  = 1.735315683711e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00220 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.04489 sec)
+--------------------------------------------------------------------------
+================================= STEP 6 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00915765 [Myr] 
+Tentative time step : 0.00241577 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.102604605640e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.386260780808e-03 
+  1 MMFD   ||F||/||F0||=1.091425e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 2.078508396186e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016715 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.735252284215e-09 
+      |Div|_2   = 3.979217526043e-09 
+   Momentum: 
+      |mRes|_2  = 2.040062604877e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00242 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.044763 sec)
+--------------------------------------------------------------------------
+================================= STEP 7 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01157342 [Myr] 
+Tentative time step : 0.00265734 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.472638864290e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.711910205687e-03 
+  1 MMFD   ||F||/||F0||=1.068902e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 2.415255252641e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016505 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.015652940285e-09 
+      |Div|_2   = 4.386920646664e-09 
+   Momentum: 
+      |mRes|_2  = 2.375080463439e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00266 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.044343 sec)
+--------------------------------------------------------------------------
+================================= STEP 8 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01423076 [Myr] 
+Tentative time step : 0.00292308 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.852567727526e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.069170585000e-03 
+  1 MMFD   ||F||/||F0||=1.056223e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 2.726289925245e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016444 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.317490413905e-09 
+      |Div|_2   = 4.824021818871e-09 
+   Momentum: 
+      |mRes|_2  = 2.683271304100e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00292 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.046227 sec)
+--------------------------------------------------------------------------
+================================= STEP 9 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01715383 [Myr] 
+Tentative time step : 0.00321538 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.250209030271e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.460658277134e-03 
+  1 MMFD   ||F||/||F0||=1.049515e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 3.083079276530e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.017511 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.633561406113e-09 
+      |Div|_2   = 5.281650522737e-09 
+   Momentum: 
+      |mRes|_2  = 3.037502181551e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00322 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.050408 sec)
+--------------------------------------------------------------------------
+================================ STEP 10 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02036922 [Myr] 
+Tentative time step : 0.00353692 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.700056332470e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.889223119056e-03 
+  1 MMFD   ||F||/||F0||=1.040248e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 3.641731737740e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.017855 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.953814211260e-09 
+      |Div|_2   = 5.748271729271e-09 
+   Momentum: 
+      |mRes|_2  = 3.596078943923e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00354 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.052336 sec)
+--------------------------------------------------------------------------
+================================ STEP 11 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02390614 [Myr] 
+Tentative time step : 0.00389061 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.162337333089e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.357970568821e-03 
+  1 MMFD   ||F||/||F0||=1.037896e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 4.153678964252e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016642 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.282618180001e-09 
+      |Div|_2   = 6.228378215097e-09 
+   Momentum: 
+      |mRes|_2  = 4.106716691734e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00389 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.047828 sec)
+--------------------------------------------------------------------------
+================================ STEP 12 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02779675 [Myr] 
+Tentative time step : 0.00427968 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.668035152397e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.870214130655e-03 
+  1 MMFD   ||F||/||F0||=1.035670e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 4.774417893193e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.017478 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.610714452114e-09 
+      |Div|_2   = 6.710354008441e-09 
+   Momentum: 
+      |mRes|_2  = 4.727026307274e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00428 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0456 sec)
+--------------------------------------------------------------------------
+================================ STEP 13 =================================
+--------------------------------------------------------------------------
+Current time        : 0.03207643 [Myr] 
+Tentative time step : 0.00470764 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.216047266680e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 6.429499536891e-03 
+  1 MMFD   ||F||/||F0||=1.034339e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 5.590579392262e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016461 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.948673896341e-09 
+      |Div|_2   = 7.208917161335e-09 
+   Momentum: 
+      |mRes|_2  = 5.543905940291e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00471 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.046239 sec)
+--------------------------------------------------------------------------
+================================ STEP 14 =================================
+--------------------------------------------------------------------------
+Current time        : 0.03678407 [Myr] 
+Tentative time step : 0.00500000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.719841961470e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 6.795499794396e-03 
+  1 MMFD   ||F||/||F0||=1.011259e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 6.174467463405e-08 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 2
+SNES solution time      : 0.016449 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.166907878505e-09 
+      |Div|_2   = 7.529411770246e-09 
+   Momentum: 
+      |mRes|_2  = 6.128387066806e-08 
+--------------------------------------------------------------------------
+Actual time step : 0.00500 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.046292 sec)
+--------------------------------------------------------------------------
+================================ STEP 15 =================================
+--------------------------------------------------------------------------
+Current time        : 0.04178407 [Myr] 
+Tentative time step : 0.00500000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.830945458421e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.347920795969e+00 
+  1 MMFD   ||F||/||F0||=4.026655e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 6.983932788567e-01 
+  2 MMFD   ||F||/||F0||=1.197736e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  3 SNES Function norm 7.014624897424e-05 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 3
+SNES solution time      : 0.023826 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.695136374187e-07 
+      |Div|_2   = 3.565726502524e-06 
+   Momentum: 
+      |mRes|_2  = 7.005556251766e-05 
+--------------------------------------------------------------------------
+Actual time step : 0.00500 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.046938 sec)
+--------------------------------------------------------------------------
+================================ STEP 16 =================================
+--------------------------------------------------------------------------
+Current time        : 0.04678407 [Myr] 
+Tentative time step : 0.00500000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.556677310528e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.012810074279e-01 
+  1 MMFD   ||F||/||F0||=7.645351e-02 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 3
+  2 SNES Function norm 6.060436021371e-03 
+  2 MMFD   ||F||/||F0||=9.243151e-04 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 6
+  3 SNES Function norm 2.879245043400e-06 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 3
+SNES solution time      : 0.036411 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 6.520731928246e-09 
+      |Div|_2   = 1.769240852162e-08 
+   Momentum: 
+      |mRes|_2  = 2.879190684659e-06 
+--------------------------------------------------------------------------
+Actual time step : 0.00500 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.050442 sec)
+--------------------------------------------------------------------------
+================================ STEP 17 =================================
+--------------------------------------------------------------------------
+Current time        : 0.05178407 [Myr] 
+Tentative time step : 0.00500000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.736067867733e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.848849215815e+00 
+  1 MMFD   ||F||/||F0||=3.223200e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 6.916288711145e-01 
+  2 MMFD   ||F||/||F0||=1.205754e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  3 SNES Function norm 1.049710715732e-02 
+  3 MMFD   ||F||/||F0||=1.830018e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 6
+  4 SNES Function norm 6.703942592621e-06 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 4
+SNES solution time      : 0.045843 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 6.820804303870e-11 
+      |Div|_2   = 2.852964681295e-10 
+   Momentum: 
+      |mRes|_2  = 6.703942586550e-06 
+--------------------------------------------------------------------------
+Actual time step : 0.00500 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.051005 sec)
+--------------------------------------------------------------------------
+================================ STEP 18 =================================
+--------------------------------------------------------------------------
+Current time        : 0.05678407 [Myr] 
+Tentative time step : 0.00500000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.246388509673e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 6.781229166837e-01 
+  1 MMFD   ||F||/||F0||=1.085624e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 3
+  2 SNES Function norm 1.709210911903e-02 
+  2 MMFD   ||F||/||F0||=2.736319e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 6
+  3 SNES Function norm 2.888991757249e-05 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 3
+SNES solution time      : 0.035928 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.696206301696e-08 
+      |Div|_2   = 2.996969220589e-08 
+   Momentum: 
+      |mRes|_2  = 2.888990202757e-05 
+--------------------------------------------------------------------------
+Actual time step : 0.00500 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.046788 sec)
+--------------------------------------------------------------------------
+================================ STEP 19 =================================
+--------------------------------------------------------------------------
+Current time        : 0.06178407 [Myr] 
+Tentative time step : 0.00500000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.988560682141e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.457644986344e+00 
+  1 MMFD   ||F||/||F0||=2.434049e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 3
+  2 SNES Function norm 6.739596076267e-01 
+  2 MMFD   ||F||/||F0||=1.125412e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  3 SNES Function norm 1.938847421615e-02 
+  3 MMFD   ||F||/||F0||=3.237585e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 6
+  4 SNES Function norm 4.341590815546e-05 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 4
+SNES solution time      : 0.046461 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 7.877890053720e-09 
+      |Div|_2   = 2.357127246209e-08 
+   Momentum: 
+      |mRes|_2  = 4.341590175683e-05 
+--------------------------------------------------------------------------
+Actual time step : 0.00500 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.048395 sec)
+--------------------------------------------------------------------------
+================================ STEP 20 =================================
+--------------------------------------------------------------------------
+Current time        : 0.06678407 [Myr] 
+Tentative time step : 0.00500000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.937821315151e+00 
+  0 PICARD ||F||/||F0||=1.000000e+00 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.611396461200e-01 
+  1 MMFD   ||F||/||F0||=1.618674e-01 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 3
+  2 SNES Function norm 4.601938482418e-01 
+  2 MMFD   ||F||/||F0||=7.750214e-02 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 3
+  3 SNES Function norm 2.260835210129e-02 
+  3 MMFD   ||F||/||F0||=3.807516e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 6
+  4 SNES Function norm 9.580723568444e-05 
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 4
+SNES solution time      : 0.047746 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.632232820020e-08 
+      |Div|_2   = 1.566984698708e-07 
+   Momentum: 
+      |mRes|_2  = 9.580710753949e-05 
+--------------------------------------------------------------------------
+Actual time step : 0.00500 [Myr] 
+--------------------------------------------------------------------------
+Saving output ... done (0.046481 sec)
+--------------------------------------------------------------------------
+=========================== SOLUTION IS DONE! ============================
+--------------------------------------------------------------------------
+Total solution time : 1.75692 (sec) 
+--------------------------------------------------------------------------

--- a/test/t4_Loc/t4_Loc1_d_MUMPS_VEP_VPReg_opt-p1.expected
+++ b/test/t4_Loc/t4_Loc1_d_MUMPS_VEP_VPReg_opt-p1.expected
@@ -1,6 +1,6 @@
 -------------------------------------------------------------------------- 
                    Lithosphere and Mantle Evolution Model                   
-     Compiled: Date: Feb 12 2024 - Time: 16:48:00 	    
+     Compiled: Date: Feb 21 2024 - Time: 14:39:07 	    
      Version : 2.1.3 
 -------------------------------------------------------------------------- 
         STAGGERED-GRID FINITE DIFFERENCE CANONICAL IMPLEMENTATION           
@@ -106,7 +106,7 @@ Advection parameters:
    Background phase ID           : 1 
    Interpolation constant        : 0.666667 
 --------------------------------------------------------------------------
-Reading geometric primitives ... done (0.000985 sec)
+Reading geometric primitives ... done (0.00186825 sec)
 --------------------------------------------------------------------------
 Output parameters:
    Output file name                        : test_vep_analytical 
@@ -141,649 +141,649 @@ Solver parameters specified:
    Solver type                   : serial direct/lu 
    Solver package                : petsc 
 --------------------------------------------------------------------------
-Initializing pressure with lithostatic pressure ... done (0.000262 sec)
+Initializing pressure with lithostatic pressure ... done (0.000785589 sec)
 --------------------------------------------------------------------------
 ============================== INITIAL GUESS =============================
 --------------------------------------------------------------------------
   0 SNES Function norm 3.933752108544e+02 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 1.339923933353e-01 
+  1 SNES Function norm 1.339923933352e-01 
   1 MMFD   ||F||/||F0||=3.406224e-04 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 2.581413956547e-07 
+  2 SNES Function norm 2.574513644616e-07 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 2
-SNES solution time      : 0.015817 (sec)
+SNES solution time      : 0.02654 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 9.971043786811e-12 
-      |Div|_2   = 1.119873066804e-10 
+      |Div|_inf = 1.005292810802e-11 
+      |Div|_2   = 1.123750910567e-10 
    Momentum: 
-      |mRes|_2  = 2.581413713634e-07 
+      |mRes|_2  = 2.574513399363e-07 
 --------------------------------------------------------------------------
-Saving output ... done (0.052931 sec)
+Saving output ... done (0.0360656 sec)
 --------------------------------------------------------------------------
 ================================= STEP 1 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00000000 [Myr] 
 Tentative time step : 0.00150000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 3.811109048114e+00 
+  0 SNES Function norm 3.811109047952e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 7.877758388130e-03 
+  1 SNES Function norm 7.877758388204e-03 
   1 MMFD   ||F||/||F0||=2.067051e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.787357117544e-08 
+  2 SNES Function norm 1.809154622095e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017386 (sec)
+SNES solution time      : 0.0273676 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 4.235337728909e-10 
-      |Div|_2   = 1.058682117918e-09 
+      |Div|_inf = 4.234794930089e-10 
+      |Div|_2   = 1.060267434353e-09 
    Momentum: 
-      |mRes|_2  = 1.784218985262e-08 
+      |mRes|_2  = 1.806045064866e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00150 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2200e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7401e-03 s
 --------------------------------------------------------------------------
-Saving output ... done (0.050447 sec)
+Saving output ... done (0.034229 sec)
 --------------------------------------------------------------------------
 ================================= STEP 2 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00150000 [Myr] 
 Tentative time step : 0.00165000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 1.848649079226e+00 
+  0 SNES Function norm 1.848649079189e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.358739533649e-03 
+  1 SNES Function norm 2.358739533663e-03 
   1 MMFD   ||F||/||F0||=1.275926e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.178128428405e-08 
+  2 SNES Function norm 1.118219674396e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.01749 (sec)
+SNES solution time      : 0.0274603 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 1.710931932616e-09 
-      |Div|_2   = 2.495831088499e-09 
+      |Div|_inf = 1.710845191102e-09 
+      |Div|_2   = 2.495699618910e-09 
    Momentum: 
-      |mRes|_2  = 1.151388234087e-08 
+      |mRes|_2  = 1.090013795476e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00165 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.3980e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7263e-03 s
 --------------------------------------------------------------------------
 ================================= STEP 3 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00315000 [Myr] 
 Tentative time step : 0.00181500 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 2.114718827807e+00 
+  0 SNES Function norm 2.114718827779e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.577984395597e-03 
+  1 SNES Function norm 2.577984395617e-03 
   1 MMFD   ||F||/||F0||=1.219067e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.327385661256e-08 
+  2 SNES Function norm 1.315808641797e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017128 (sec)
+SNES solution time      : 0.0273566 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 1.953894243424e-09 
-      |Div|_2   = 2.845965192590e-09 
+      |Div|_inf = 1.953801502530e-09 
+      |Div|_2   = 2.845868407302e-09 
    Momentum: 
-      |mRes|_2  = 1.296517456471e-08 
+      |mRes|_2  = 1.284664435529e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00182 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2670e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7246e-03 s
 --------------------------------------------------------------------------
 ================================= STEP 4 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00496500 [Myr] 
 Tentative time step : 0.00199650 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 2.420242367766e+00 
+  0 SNES Function norm 2.420242368339e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.821589529929e-03 
+  1 SNES Function norm 2.821589529908e-03 
   1 MMFD   ||F||/||F0||=1.165829e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.572744397147e-08 
+  2 SNES Function norm 1.573432048613e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017 (sec)
+SNES solution time      : 0.0272589 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.207158488896e-09 
-      |Div|_2   = 3.214934160633e-09 
+      |Div|_inf = 2.208330885560e-09 
+      |Div|_2   = 3.216341304572e-09 
    Momentum: 
-      |mRes|_2  = 1.539534644685e-08 
+      |mRes|_2  = 1.540207744990e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00200 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.3110e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7334e-03 s
 --------------------------------------------------------------------------
 ================================= STEP 5 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00696150 [Myr] 
 Tentative time step : 0.00219615 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 2.751139893726e+00 
+  0 SNES Function norm 2.751139893145e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 3.090670144965e-03 
+  1 SNES Function norm 3.090670144875e-03 
   1 MMFD   ||F||/||F0||=1.123414e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.889041421836e-08 
+  2 SNES Function norm 1.812813256507e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017158 (sec)
+SNES solution time      : 0.0274487 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.471803989803e-09 
-      |Div|_2   = 3.599200526754e-09 
+      |Div|_inf = 2.471822376773e-09 
+      |Div|_2   = 3.599293293035e-09 
    Momentum: 
-      |mRes|_2  = 1.854436585352e-08 
+      |mRes|_2  = 1.776722482796e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00220 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1960e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.8159e-03 s
 --------------------------------------------------------------------------
-Saving output ... done (0.04938 sec)
+Saving output ... done (0.0318635 sec)
 --------------------------------------------------------------------------
 ================================= STEP 6 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00915765 [Myr] 
 Tentative time step : 0.00241577 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 3.090915482106e+00 
+  0 SNES Function norm 3.090915482168e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 3.386939595547e-03 
+  1 SNES Function norm 3.386939595499e-03 
   1 MMFD   ||F||/||F0||=1.095772e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 2.059524252045e-08 
+  2 SNES Function norm 2.089355903927e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016567 (sec)
+SNES solution time      : 0.0274482 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.738492677790e-09 
-      |Div|_2   = 3.982766170163e-09 
+      |Div|_inf = 2.731407803495e-09 
+      |Div|_2   = 3.973851337330e-09 
    Momentum: 
-      |mRes|_2  = 2.020647391581e-08 
+      |mRes|_2  = 2.051217479635e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00242 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1870e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7692e-03 s
 --------------------------------------------------------------------------
 ================================= STEP 7 =================================
 --------------------------------------------------------------------------
 Current time        : 0.01157342 [Myr] 
 Tentative time step : 0.00265734 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 3.462091803012e+00 
+  0 SNES Function norm 3.462091805757e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 3.712474024620e-03 
+  1 SNES Function norm 3.712474024446e-03 
   1 MMFD   ||F||/||F0||=1.072321e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 2.450306895193e-08 
+  2 SNES Function norm 2.385488289128e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016921 (sec)
+SNES solution time      : 0.0273628 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 3.023714064009e-09 
-      |Div|_2   = 4.396283454136e-09 
+      |Div|_inf = 3.016094373386e-09 
+      |Div|_2   = 4.386681652231e-09 
    Momentum: 
-      |mRes|_2  = 2.410545747033e-08 
+      |mRes|_2  = 2.344808013119e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00266 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2940e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7129e-03 s
 --------------------------------------------------------------------------
 ================================= STEP 8 =================================
 --------------------------------------------------------------------------
 Current time        : 0.01423076 [Myr] 
 Tentative time step : 0.00292308 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 3.843453837455e+00 
+  0 SNES Function norm 3.843453841969e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 4.069632368221e-03 
+  1 SNES Function norm 4.069632368022e-03 
   1 MMFD   ||F||/||F0||=1.058848e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 2.723599969895e-08 
+  2 SNES Function norm 2.771646159494e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.01694 (sec)
+SNES solution time      : 0.0277436 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 3.317078528118e-09 
-      |Div|_2   = 4.820730711401e-09 
+      |Div|_inf = 3.312513184757e-09 
+      |Div|_2   = 4.814617311368e-09 
    Momentum: 
-      |mRes|_2  = 2.680597386795e-08 
+      |mRes|_2  = 2.729508570217e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00292 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2050e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7735e-03 s
 --------------------------------------------------------------------------
 ================================= STEP 9 =================================
 --------------------------------------------------------------------------
 Current time        : 0.01715383 [Myr] 
 Tentative time step : 0.00321538 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 4.242576104052e+00 
+  0 SNES Function norm 4.242576103936e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 4.461032330302e-03 
+  1 SNES Function norm 4.461032329832e-03 
   1 MMFD   ||F||/||F0||=1.051491e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 3.140446928053e-08 
+  2 SNES Function norm 3.073302486914e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016971 (sec)
+SNES solution time      : 0.0274127 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 3.635257079973e-09 
-      |Div|_2   = 5.278576258604e-09 
+      |Div|_inf = 3.634524713093e-09 
+      |Div|_2   = 5.277592350774e-09 
    Momentum: 
-      |mRes|_2  = 3.095766986505e-08 
+      |mRes|_2  = 3.027648983265e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00322 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2650e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7692e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 10 =================================
 --------------------------------------------------------------------------
 Current time        : 0.02036922 [Myr] 
 Tentative time step : 0.00353692 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 4.693850651084e+00 
+  0 SNES Function norm 4.693850650923e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 4.889523310692e-03 
+  1 SNES Function norm 4.889523310672e-03 
   1 MMFD   ||F||/||F0||=1.041687e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 3.630158729596e-08 
+  2 SNES Function norm 3.633027160126e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017259 (sec)
+SNES solution time      : 0.0274611 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 3.950294001328e-09 
-      |Div|_2   = 5.733962451262e-09 
+      |Div|_inf = 3.952857463227e-09 
+      |Div|_2   = 5.737334257428e-09 
    Momentum: 
-      |mRes|_2  = 3.584587723593e-08 
+      |mRes|_2  = 3.587438682737e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00354 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2930e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7520e-03 s
 --------------------------------------------------------------------------
-Saving output ... done (0.049568 sec)
+Saving output ... done (0.0316679 sec)
 --------------------------------------------------------------------------
 ================================ STEP 11 =================================
 --------------------------------------------------------------------------
 Current time        : 0.02390614 [Myr] 
 Tentative time step : 0.00389061 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.157375600543e+00 
+  0 SNES Function norm 5.157375599102e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 5.358209904616e-03 
+  1 SNES Function norm 5.358209904815e-03 
   1 MMFD   ||F||/||F0||=1.038941e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 4.197440878059e-08 
+  2 SNES Function norm 4.123469975221e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016855 (sec)
+SNES solution time      : 0.0273542 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 4.271330743455e-09 
-      |Div|_2   = 6.196961540432e-09 
+      |Div|_inf = 4.275261150958e-09 
+      |Div|_2   = 6.202113120640e-09 
    Momentum: 
-      |mRes|_2  = 4.151443917658e-08 
+      |mRes|_2  = 4.076560138761e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00389 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1280e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7976e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 12 =================================
 --------------------------------------------------------------------------
 Current time        : 0.02779675 [Myr] 
 Tentative time step : 0.00427968 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.664134313290e+00 
+  0 SNES Function norm 5.664134311390e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 5.870402715891e-03 
+  1 SNES Function norm 5.870402716052e-03 
   1 MMFD   ||F||/||F0||=1.036417e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 4.709751921197e-08 
+  2 SNES Function norm 4.698926166877e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.01711 (sec)
+SNES solution time      : 0.0273845 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 4.608713767074e-09 
-      |Div|_2   = 6.682013145804e-09 
+      |Div|_inf = 4.613550869028e-09 
+      |Div|_2   = 6.688565652021e-09 
    Momentum: 
-      |mRes|_2  = 4.662110054730e-08 
+      |mRes|_2  = 4.651079231420e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00428 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1860e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7863e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 13 =================================
 --------------------------------------------------------------------------
 Current time        : 0.03207643 [Myr] 
 Tentative time step : 0.00470764 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.213056241530e+00 
+  0 SNES Function norm 6.213056241484e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 6.429647609026e-03 
+  1 SNES Function norm 6.429647609337e-03 
   1 MMFD   ||F||/||F0||=1.034861e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 5.481987684780e-08 
+  2 SNES Function norm 5.520560982965e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017115 (sec)
+SNES solution time      : 0.0274017 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 4.956072265661e-09 
-      |Div|_2   = 7.180187580114e-09 
+      |Div|_inf = 4.948855361533e-09 
+      |Div|_2   = 7.170694905054e-09 
    Momentum: 
-      |mRes|_2  = 5.434762003917e-08 
+      |mRes|_2  = 5.473792552922e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00471 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1800e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.8324e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 14 =================================
 --------------------------------------------------------------------------
 Current time        : 0.03678407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.715759172251e+00 
+  0 SNES Function norm 6.715759177014e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 6.795653423084e-03 
+  1 SNES Function norm 6.795653422477e-03 
   1 MMFD   ||F||/||F0||=1.011897e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 6.505604947780e-08 
+  2 SNES Function norm 6.184238984519e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017031 (sec)
+SNES solution time      : 0.0273852 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 5.153297681036e-09 
-      |Div|_2   = 7.464527251906e-09 
+      |Div|_inf = 5.158000153729e-09 
+      |Div|_2   = 7.470644414220e-09 
    Momentum: 
-      |mRes|_2  = 6.462639094490e-08 
+      |mRes|_2  = 6.138949954023e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1840e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7291e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 15 =================================
 --------------------------------------------------------------------------
 Current time        : 0.04178407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.824801425382e+00 
+  0 SNES Function norm 5.824827222138e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.348246737641e+00 
-  1 MMFD   ||F||/||F0||=4.031462e-01 
+  1 SNES Function norm 2.348175359399e+00 
+  1 MMFD   ||F||/||F0||=4.031322e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 6.976287463720e-01 
-  2 MMFD   ||F||/||F0||=1.197687e-01 
+  2 SNES Function norm 6.968906345065e-01 
+  2 MMFD   ||F||/||F0||=1.196414e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  3 SNES Function norm 7.124482597394e-05 
+  3 SNES Function norm 7.113875059441e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 3
-SNES solution time      : 0.024786 (sec)
+SNES solution time      : 0.0389197 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 7.807299759453e-07 
-      |Div|_2   = 3.586559269188e-06 
+      |Div|_inf = 7.796818410311e-07 
+      |Div|_2   = 3.582291049887e-06 
    Momentum: 
-      |mRes|_2  = 7.115449262461e-05 
+      |mRes|_2  = 7.104849771084e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.3020e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7232e-03 s
 --------------------------------------------------------------------------
-Saving output ... done (0.048664 sec)
+Saving output ... done (0.0320606 sec)
 --------------------------------------------------------------------------
 ================================ STEP 16 =================================
 --------------------------------------------------------------------------
 Current time        : 0.04678407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.556322528849e+00 
+  0 SNES Function norm 6.556342258306e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 5.008077097596e-01 
-  1 MMFD   ||F||/||F0||=7.638546e-02 
+  1 SNES Function norm 5.007997539942e-01 
+  1 MMFD   ||F||/||F0||=7.638402e-02 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 5.925350117790e-03 
-  2 MMFD   ||F||/||F0||=9.037612e-04 
+  2 SNES Function norm 5.925555677546e-03 
+  2 MMFD   ||F||/||F0||=9.037899e-04 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  3 SNES Function norm 2.609196102131e-06 
+  3 SNES Function norm 2.609440745176e-06 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 3
-SNES solution time      : 0.036927 (sec)
+SNES solution time      : 0.0491042 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 5.033833483324e-09 
-      |Div|_2   = 1.472903989208e-08 
+      |Div|_inf = 5.036613995443e-09 
+      |Div|_2   = 1.473466062842e-08 
    Momentum: 
-      |mRes|_2  = 2.609154528724e-06 
+      |mRes|_2  = 2.609399143934e-06 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.2340e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7313e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 17 =================================
 --------------------------------------------------------------------------
 Current time        : 0.05178407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.735628837832e+00 
+  0 SNES Function norm 5.735659627712e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 1.848828983807e+00 
-  1 MMFD   ||F||/||F0||=3.223411e-01 
+  1 SNES Function norm 1.848759268329e+00 
+  1 MMFD   ||F||/||F0||=3.223272e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 6.911709034965e-01 
-  2 MMFD   ||F||/||F0||=1.205048e-01 
+  2 SNES Function norm 6.914009953670e-01 
+  2 MMFD   ||F||/||F0||=1.205443e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  3 SNES Function norm 1.033383316118e-02 
-  3 MMFD   ||F||/||F0||=1.801691e-03 
+  3 SNES Function norm 1.033606907054e-02 
+  3 MMFD   ||F||/||F0||=1.802072e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  4 SNES Function norm 6.172344179005e-06 
+  4 SNES Function norm 6.174303867141e-06 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 4
-SNES solution time      : 0.042438 (sec)
+SNES solution time      : 0.0613904 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 8.554864318917e-11 
-      |Div|_2   = 2.621203706221e-10 
+      |Div|_inf = 8.565998431409e-11 
+      |Div|_2   = 2.625222165606e-10 
    Momentum: 
-      |mRes|_2  = 6.172344173440e-06 
+      |mRes|_2  = 6.174303861560e-06 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.4070e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7236e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 18 =================================
 --------------------------------------------------------------------------
 Current time        : 0.05678407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.245465109445e+00 
+  0 SNES Function norm 6.245483400289e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 6.778755053808e-01 
-  1 MMFD   ||F||/||F0||=1.085388e-01 
+  1 SNES Function norm 6.778938733106e-01 
+  1 MMFD   ||F||/||F0||=1.085415e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 1.653426031131e-02 
-  2 MMFD   ||F||/||F0||=2.647403e-03 
+  2 SNES Function norm 1.653246740402e-02 
+  2 MMFD   ||F||/||F0||=2.647108e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  3 SNES Function norm 2.831492269092e-05 
+  3 SNES Function norm 2.824029220008e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 3
-SNES solution time      : 0.03664 (sec)
+SNES solution time      : 0.04954 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.023878483550e-08 
-      |Div|_2   = 3.783486966760e-08 
+      |Div|_inf = 1.954379993539e-08 
+      |Div|_2   = 3.617138098604e-08 
    Momentum: 
-      |mRes|_2  = 2.831489741312e-05 
+      |mRes|_2  = 2.824026903514e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1790e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7658e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 19 =================================
 --------------------------------------------------------------------------
 Current time        : 0.06178407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.987769087126e+00 
+  0 SNES Function norm 5.987801313433e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 1.457925884897e+00 
-  1 MMFD   ||F||/||F0||=2.434840e-01 
+  1 SNES Function norm 1.457867070747e+00 
+  1 MMFD   ||F||/||F0||=2.434729e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 6.734023299299e-01 
-  2 MMFD   ||F||/||F0||=1.124630e-01 
+  2 SNES Function norm 6.737291288068e-01 
+  2 MMFD   ||F||/||F0||=1.125169e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  3 SNES Function norm 1.912501027817e-02 
-  3 MMFD   ||F||/||F0||=3.194013e-03 
+  3 SNES Function norm 1.913326937791e-02 
+  3 MMFD   ||F||/||F0||=3.195375e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  4 SNES Function norm 4.228875320225e-05 
+  4 SNES Function norm 4.230991713703e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 4
-SNES solution time      : 0.044421 (sec)
+SNES solution time      : 0.0640459 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 7.662728549459e-09 
-      |Div|_2   = 2.309216207531e-08 
+      |Div|_inf = 7.666979471872e-09 
+      |Div|_2   = 2.311346716911e-08 
    Momentum: 
-      |mRes|_2  = 4.228874689741e-05 
+      |mRes|_2  = 4.230991082371e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.1890e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7255e-03 s
 --------------------------------------------------------------------------
 ================================ STEP 20 =================================
 --------------------------------------------------------------------------
 Current time        : 0.06678407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.936958206227e+00 
+  0 SNES Function norm 5.936973947351e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 9.609628867518e-01 
-  1 MMFD   ||F||/||F0||=1.618612e-01 
+  1 SNES Function norm 9.609677990468e-01 
+  1 MMFD   ||F||/||F0||=1.618615e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 4.592122905002e-01 
-  2 MMFD   ||F||/||F0||=7.734808e-02 
+  2 SNES Function norm 4.594749524282e-01 
+  2 MMFD   ||F||/||F0||=7.739211e-02 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  3 SNES Function norm 2.241703226847e-02 
-  3 MMFD   ||F||/||F0||=3.775845e-03 
+  3 SNES Function norm 2.241750022317e-02 
+  3 MMFD   ||F||/||F0||=3.775914e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  4 SNES Function norm 9.313852809086e-05 
+  4 SNES Function norm 9.319563828793e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 4
-SNES solution time      : 0.049564 (sec)
+SNES solution time      : 0.0658038 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 8.319392843060e-08 
-      |Div|_2   = 1.494185102077e-07 
+      |Div|_inf = 8.319597083776e-08 
+      |Div|_2   = 1.493425396479e-07 
    Momentum: 
-      |mRes|_2  = 9.313840823764e-05 
+      |mRes|_2  = 9.319551862992e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
 Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 2.0990e-03 s
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.7296e-03 s
 --------------------------------------------------------------------------
-Saving output ... done (0.047289 sec)
+Saving output ... done (0.0322833 sec)
 --------------------------------------------------------------------------
 =========================== SOLUTION IS DONE! ============================
 --------------------------------------------------------------------------
-Total solution time : 1.32788 (sec) 
+Total solution time : 2.39331 (sec) 
 --------------------------------------------------------------------------

--- a/test/t4_Loc/t4_Loc1_d_MUMPS_VEP_VPReg_opt-p1.expected
+++ b/test/t4_Loc/t4_Loc1_d_MUMPS_VEP_VPReg_opt-p1.expected
@@ -53,22 +53,22 @@ Softening laws:
 --------------------------------------------------------------------------
 Material parameters: 
 --------------------------------------------------------------------------
-- Melt factor mfc = 0.000000   Phase ID : 0   
+   Phase ID : 0   
    (dens)   : rho = 2700. [kg/m^3]  
    (elast)  : G = 5e+10 [Pa]  Kb = 8e+10 [Pa]  E = 1.24138e+11 [Pa]  nu = 0.241379 [ ]  Vp = 7370.28 [m/s]  Vs = 4303.31 [m/s]  
    (diff)   : eta = 1e+21 [Pa*s]  Bd = 5e-22 [1/Pa/s]  
    (plast)  : ch = 5e+07 [Pa]  fr = 30. [deg]  frSoftID = 0 chSoftID = 0 
 
-- Melt factor mfc = 0.000000   Phase ID : 1   
+   Phase ID : 1   
    (dens)   : rho = 2700. [kg/m^3]  
    (elast)  : G = 5e+10 [Pa]  Kb = 8e+10 [Pa]  E = 1.24138e+11 [Pa]  nu = 0.241379 [ ]  Vp = 7370.28 [m/s]  Vs = 4303.31 [m/s]  
    (diff)   : eta = 1e+24 [Pa*s]  Bd = 5e-25 [1/Pa/s]  
    (plast)  : ch = 5e+07 [Pa]  fr = 30. [deg]  eta_vp = 1e+21 [Pa*s]  frSoftID = 0 chSoftID = 0 
 
-- Melt factor mfc = 0.000000   Phase ID : 2   
+   Phase ID : 2   
    (dens)   : rho = 100. [kg/m^3]  
    (elast)  : G = 5e+10 [Pa]  Kb = 8e+10 [Pa]  E = 1.24138e+11 [Pa]  nu = 0.241379 [ ]  Vp = 38297.1 [m/s]  Vs = 22360.7 [m/s]  
-   (diff)   : eta = 1e+19 [Pa*s]  Bd = 5e-20 [1/Pa/s]  
+   (diff)   : eta = 1e+20 [Pa*s]  Bd = 5e-21 [1/Pa/s]  
    (plast)  : ch = 5e+07 [Pa]  fr = 30. [deg]  frSoftID = 0 chSoftID = 0 
 
 --------------------------------------------------------------------------
@@ -105,7 +105,7 @@ Advection parameters:
    Marker distribution type      : uniform
    Background phase ID           : 1 
 --------------------------------------------------------------------------
-Reading geometric primitives ... done (0.000879 sec)
+Reading geometric primitives ... done (0.000944 sec)
 --------------------------------------------------------------------------
 Output parameters:
    Output file name                        : test_vep_analytical 
@@ -140,7 +140,7 @@ Solver parameters specified:
    Solver type                   : serial direct/lu 
    Solver package                : petsc 
 --------------------------------------------------------------------------
-Initializing pressure with lithostatic pressure ... done (0.000257 sec)
+Initializing pressure with lithostatic pressure ... done (0.000253 sec)
 --------------------------------------------------------------------------
 ============================== INITIAL GUESS =============================
 --------------------------------------------------------------------------
@@ -154,7 +154,7 @@ Initializing pressure with lithostatic pressure ... done (0.000257 sec)
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 2
-SNES solution time      : 0.014419 (sec)
+SNES solution time      : 0.015477 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
@@ -163,596 +163,596 @@ Residual summary:
    Momentum: 
       |mRes|_2  = 2.581413713634e-07 
 --------------------------------------------------------------------------
-Saving output ... done (0.045754 sec)
+Saving output ... done (0.048228 sec)
 --------------------------------------------------------------------------
 ================================= STEP 1 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00000000 [Myr] 
 Tentative time step : 0.00150000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 3.846888661767e+00 
+  0 SNES Function norm 3.811109048114e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 7.090317869281e-02 
-  1 MMFD   ||F||/||F0||=1.843131e-02 
-  Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  2 SNES Function norm 2.006303773010e-05 
+  1 SNES Function norm 7.877758388130e-03 
+  1 MMFD   ||F||/||F0||=2.067051e-03 
+  Linear js_ solve converged due to CONVERGED_RTOL iterations 2
+  2 SNES Function norm 1.787357117544e-08 
 --------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.015159 (sec)
+SNES solution time      : 0.016657 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 1.215949385803e-07 
-      |Div|_2   = 1.697874183247e-06 
+      |Div|_inf = 4.235337728909e-10 
+      |Div|_2   = 1.058682117918e-09 
    Momentum: 
-      |mRes|_2  = 1.999106565988e-05 
+      |mRes|_2  = 1.784218985262e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00150 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.047551 sec)
+Saving output ... done (0.054367 sec)
 --------------------------------------------------------------------------
 ================================= STEP 2 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00150000 [Myr] 
 Tentative time step : 0.00165000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 1.851816074516e+00 
+  0 SNES Function norm 1.848643372433e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.357632098703e-03 
-  1 MMFD   ||F||/||F0||=1.273146e-03 
+  1 SNES Function norm 2.358737257691e-03 
+  1 MMFD   ||F||/||F0||=1.275929e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.131639023585e-08 
+  2 SNES Function norm 1.126410787629e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017975 (sec)
+SNES solution time      : 0.017674 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 1.708357723442e-09 
-      |Div|_2   = 2.492587803068e-09 
+      |Div|_inf = 1.708728112859e-09 
+      |Div|_2   = 2.493258278823e-09 
    Momentum: 
-      |mRes|_2  = 1.103846429600e-08 
+      |mRes|_2  = 1.098470706954e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00165 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.046875 sec)
+Saving output ... done (0.049236 sec)
 --------------------------------------------------------------------------
 ================================= STEP 3 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00315000 [Myr] 
 Tentative time step : 0.00181500 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 2.121556478761e+00 
+  0 SNES Function norm 2.114715781027e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.576972292346e-03 
-  1 MMFD   ||F||/||F0||=1.214661e-03 
+  1 SNES Function norm 2.577977248031e-03 
+  1 MMFD   ||F||/||F0||=1.219066e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.333793447359e-08 
+  2 SNES Function norm 1.354120920390e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016712 (sec)
+SNES solution time      : 0.016602 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 1.953576255400e-09 
-      |Div|_2   = 2.847670944656e-09 
+      |Div|_inf = 1.954759254964e-09 
+      |Div|_2   = 2.847197109891e-09 
    Momentum: 
-      |mRes|_2  = 1.303039777646e-08 
+      |mRes|_2  = 1.323849747219e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00182 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.045331 sec)
+Saving output ... done (0.048873 sec)
 --------------------------------------------------------------------------
 ================================= STEP 4 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00496500 [Myr] 
 Tentative time step : 0.00199650 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 2.430905690615e+00 
+  0 SNES Function norm 2.420238878210e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.820665443333e-03 
-  1 MMFD   ||F||/||F0||=1.160335e-03 
+  1 SNES Function norm 2.821582397465e-03 
+  1 MMFD   ||F||/||F0||=1.165828e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.659828816228e-08 
+  2 SNES Function norm 1.528281437796e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016526 (sec)
+SNES solution time      : 0.016817 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.205807441192e-09 
-      |Div|_2   = 3.214207007390e-09 
+      |Div|_inf = 2.207595058837e-09 
+      |Div|_2   = 3.215200481294e-09 
    Momentum: 
-      |mRes|_2  = 1.628410400458e-08 
+      |mRes|_2  = 1.494077980482e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00200 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.052048 sec)
+Saving output ... done (0.048174 sec)
 --------------------------------------------------------------------------
 ================================= STEP 5 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00696150 [Myr] 
 Tentative time step : 0.00219615 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 2.763106982334e+00 
+  0 SNES Function norm 2.751142620603e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 3.089867384034e-03 
-  1 MMFD   ||F||/||F0||=1.118258e-03 
+  1 SNES Function norm 3.090663890363e-03 
+  1 MMFD   ||F||/||F0||=1.123411e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 1.772198598025e-08 
+  2 SNES Function norm 1.811313689886e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016954 (sec)
+SNES solution time      : 0.016861 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.469519595623e-09 
-      |Div|_2   = 3.596767280624e-09 
+      |Div|_inf = 2.474455116929e-09 
+      |Div|_2   = 3.602433565129e-09 
    Momentum: 
-      |mRes|_2  = 1.735315683711e-08 
+      |mRes|_2  = 1.775128729770e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00220 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.04489 sec)
+Saving output ... done (0.048225 sec)
 --------------------------------------------------------------------------
 ================================= STEP 6 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00915765 [Myr] 
 Tentative time step : 0.00241577 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 3.102604605640e+00 
+  0 SNES Function norm 3.090912363716e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 3.386260780808e-03 
-  1 MMFD   ||F||/||F0||=1.091425e-03 
+  1 SNES Function norm 3.386932694568e-03 
+  1 MMFD   ||F||/||F0||=1.095771e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 2.078508396186e-08 
+  2 SNES Function norm 2.145019811302e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016715 (sec)
+SNES solution time      : 0.016697 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.735252284215e-09 
-      |Div|_2   = 3.979217526043e-09 
+      |Div|_inf = 2.727370357288e-09 
+      |Div|_2   = 3.968722660280e-09 
    Momentum: 
-      |mRes|_2  = 2.040062604877e-08 
+      |mRes|_2  = 2.107985387838e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00242 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.044763 sec)
+Saving output ... done (0.051222 sec)
 --------------------------------------------------------------------------
 ================================= STEP 7 =================================
 --------------------------------------------------------------------------
 Current time        : 0.01157342 [Myr] 
 Tentative time step : 0.00265734 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 3.472638864290e+00 
+  0 SNES Function norm 3.462093481515e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 3.711910205687e-03 
-  1 MMFD   ||F||/||F0||=1.068902e-03 
+  1 SNES Function norm 3.712466582960e-03 
+  1 MMFD   ||F||/||F0||=1.072318e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 2.415255252641e-08 
+  2 SNES Function norm 2.434522460982e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016505 (sec)
+SNES solution time      : 0.016666 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 3.015652940285e-09 
-      |Div|_2   = 4.386920646664e-09 
+      |Div|_inf = 3.016411207275e-09 
+      |Div|_2   = 4.386892746951e-09 
    Momentum: 
-      |mRes|_2  = 2.375080463439e-08 
+      |mRes|_2  = 2.394671445792e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00266 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.044343 sec)
+Saving output ... done (0.049847 sec)
 --------------------------------------------------------------------------
 ================================= STEP 8 =================================
 --------------------------------------------------------------------------
 Current time        : 0.01423076 [Myr] 
 Tentative time step : 0.00292308 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 3.852567727526e+00 
+  0 SNES Function norm 3.843455175315e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 4.069170585000e-03 
-  1 MMFD   ||F||/||F0||=1.056223e-03 
+  1 SNES Function norm 4.069624129361e-03 
+  1 MMFD   ||F||/||F0||=1.058845e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 2.726289925245e-08 
+  2 SNES Function norm 2.772056877361e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016444 (sec)
+SNES solution time      : 0.022857 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 3.317490413905e-09 
-      |Div|_2   = 4.824021818871e-09 
+      |Div|_inf = 3.320662709290e-09 
+      |Div|_2   = 4.825540080873e-09 
    Momentum: 
-      |mRes|_2  = 2.683271304100e-08 
+      |mRes|_2  = 2.729732763588e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00292 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.046227 sec)
+Saving output ... done (0.053924 sec)
 --------------------------------------------------------------------------
 ================================= STEP 9 =================================
 --------------------------------------------------------------------------
 Current time        : 0.01715383 [Myr] 
 Tentative time step : 0.00321538 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 4.250209030271e+00 
+  0 SNES Function norm 4.242580263917e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 4.460658277134e-03 
-  1 MMFD   ||F||/||F0||=1.049515e-03 
+  1 SNES Function norm 4.461023226090e-03 
+  1 MMFD   ||F||/||F0||=1.051488e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 3.083079276530e-08 
+  2 SNES Function norm 3.059107835171e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017511 (sec)
+SNES solution time      : 0.017796 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 3.633561406113e-09 
-      |Div|_2   = 5.281650522737e-09 
+      |Div|_inf = 3.648009267067e-09 
+      |Div|_2   = 5.295169111710e-09 
    Momentum: 
-      |mRes|_2  = 3.037502181551e-08 
+      |mRes|_2  = 3.012930896650e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00322 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.050408 sec)
+Saving output ... done (0.050454 sec)
 --------------------------------------------------------------------------
 ================================ STEP 10 =================================
 --------------------------------------------------------------------------
 Current time        : 0.02036922 [Myr] 
 Tentative time step : 0.00353692 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 4.700056332470e+00 
+  0 SNES Function norm 4.693854994103e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 4.889223119056e-03 
-  1 MMFD   ||F||/||F0||=1.040248e-03 
+  1 SNES Function norm 4.889513115823e-03 
+  1 MMFD   ||F||/||F0||=1.041684e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 3.641731737740e-08 
+  2 SNES Function norm 3.572752165451e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017855 (sec)
+SNES solution time      : 0.016902 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 3.953814211260e-09 
-      |Div|_2   = 5.748271729271e-09 
+      |Div|_inf = 3.950573394523e-09 
+      |Div|_2   = 5.734518184238e-09 
    Momentum: 
-      |mRes|_2  = 3.596078943923e-08 
+      |mRes|_2  = 3.526430354860e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00354 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.052336 sec)
+Saving output ... done (0.05107 sec)
 --------------------------------------------------------------------------
 ================================ STEP 11 =================================
 --------------------------------------------------------------------------
 Current time        : 0.02390614 [Myr] 
 Tentative time step : 0.00389061 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.162337333089e+00 
+  0 SNES Function norm 5.157382781116e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 5.357970568821e-03 
-  1 MMFD   ||F||/||F0||=1.037896e-03 
+  1 SNES Function norm 5.358198397633e-03 
+  1 MMFD   ||F||/||F0||=1.038938e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 4.153678964252e-08 
+  2 SNES Function norm 4.059082540686e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016642 (sec)
+SNES solution time      : 0.016742 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 4.282618180001e-09 
-      |Div|_2   = 6.228378215097e-09 
+      |Div|_inf = 4.277244732130e-09 
+      |Div|_2   = 6.204876136013e-09 
    Momentum: 
-      |mRes|_2  = 4.106716691734e-08 
+      |mRes|_2  = 4.011377094399e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00389 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.047828 sec)
+Saving output ... done (0.050129 sec)
 --------------------------------------------------------------------------
 ================================ STEP 12 =================================
 --------------------------------------------------------------------------
 Current time        : 0.02779675 [Myr] 
 Tentative time step : 0.00427968 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.668035152397e+00 
+  0 SNES Function norm 5.664149883613e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 5.870214130655e-03 
-  1 MMFD   ||F||/||F0||=1.035670e-03 
+  1 SNES Function norm 5.870390413502e-03 
+  1 MMFD   ||F||/||F0||=1.036412e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 4.774417893193e-08 
+  2 SNES Function norm 4.626906857690e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.017478 (sec)
+SNES solution time      : 0.017135 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 4.610714452114e-09 
-      |Div|_2   = 6.710354008441e-09 
+      |Div|_inf = 4.617797686426e-09 
+      |Div|_2   = 6.693802229275e-09 
    Momentum: 
-      |mRes|_2  = 4.727026307274e-08 
+      |mRes|_2  = 4.578230792227e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00428 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.0456 sec)
+Saving output ... done (0.04854 sec)
 --------------------------------------------------------------------------
 ================================ STEP 13 =================================
 --------------------------------------------------------------------------
 Current time        : 0.03207643 [Myr] 
 Tentative time step : 0.00470764 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.216047266680e+00 
+  0 SNES Function norm 6.213066205891e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 6.429499536891e-03 
-  1 MMFD   ||F||/||F0||=1.034339e-03 
+  1 SNES Function norm 6.429633724356e-03 
+  1 MMFD   ||F||/||F0||=1.034857e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 5.590579392262e-08 
+  2 SNES Function norm 5.638614028281e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016461 (sec)
+SNES solution time      : 0.016785 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 4.948673896341e-09 
-      |Div|_2   = 7.208917161335e-09 
+      |Div|_inf = 4.944908750999e-09 
+      |Div|_2   = 7.165378161867e-09 
    Momentum: 
-      |mRes|_2  = 5.543905940291e-08 
+      |mRes|_2  = 5.592901010916e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00471 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.046239 sec)
+Saving output ... done (0.049414 sec)
 --------------------------------------------------------------------------
 ================================ STEP 14 =================================
 --------------------------------------------------------------------------
 Current time        : 0.03678407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.719841961470e+00 
+  0 SNES Function norm 6.715781328482e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 6.795499794396e-03 
-  1 MMFD   ||F||/||F0||=1.011259e-03 
+  1 SNES Function norm 6.795637914085e-03 
+  1 MMFD   ||F||/||F0||=1.011891e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 6.174467463405e-08 
+  2 SNES Function norm 6.343216796546e-08 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 2
-SNES solution time      : 0.016449 (sec)
+SNES solution time      : 0.017128 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 5.166907878505e-09 
-      |Div|_2   = 7.529411770246e-09 
+      |Div|_inf = 5.163490047917e-09 
+      |Div|_2   = 7.477987598987e-09 
    Momentum: 
-      |mRes|_2  = 6.128387066806e-08 
+      |mRes|_2  = 6.298983754756e-08 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.046292 sec)
+Saving output ... done (0.053347 sec)
 --------------------------------------------------------------------------
 ================================ STEP 15 =================================
 --------------------------------------------------------------------------
 Current time        : 0.04178407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.830945458421e+00 
+  0 SNES Function norm 5.824866260108e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 2.347920795969e+00 
-  1 MMFD   ||F||/||F0||=4.026655e-01 
+  1 SNES Function norm 2.348262008769e+00 
+  1 MMFD   ||F||/||F0||=4.031444e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 6.983932788567e-01 
-  2 MMFD   ||F||/||F0||=1.197736e-01 
+  2 SNES Function norm 6.976001417257e-01 
+  2 MMFD   ||F||/||F0||=1.197624e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  3 SNES Function norm 7.014624897424e-05 
+  3 SNES Function norm 7.125080072726e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 3
-SNES solution time      : 0.023826 (sec)
+SNES solution time      : 0.024789 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 7.695136374187e-07 
-      |Div|_2   = 3.565726502524e-06 
+      |Div|_inf = 7.806479776527e-07 
+      |Div|_2   = 3.586631235413e-06 
    Momentum: 
-      |mRes|_2  = 7.005556251766e-05 
+      |mRes|_2  = 7.116047133526e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.046938 sec)
+Saving output ... done (0.049134 sec)
 --------------------------------------------------------------------------
 ================================ STEP 16 =================================
 --------------------------------------------------------------------------
 Current time        : 0.04678407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.556677310528e+00 
+  0 SNES Function norm 6.556351475854e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 5.012810074279e-01 
-  1 MMFD   ||F||/||F0||=7.645351e-02 
+  1 SNES Function norm 5.007714285979e-01 
+  1 MMFD   ||F||/||F0||=7.637959e-02 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 6.060436021371e-03 
-  2 MMFD   ||F||/||F0||=9.243151e-04 
+  2 SNES Function norm 5.925204769458e-03 
+  2 MMFD   ||F||/||F0||=9.037351e-04 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  3 SNES Function norm 2.879245043400e-06 
+  3 SNES Function norm 2.608877515668e-06 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 3
-SNES solution time      : 0.036411 (sec)
+SNES solution time      : 0.033557 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 6.520731928246e-09 
-      |Div|_2   = 1.769240852162e-08 
+      |Div|_inf = 5.040525843032e-09 
+      |Div|_2   = 1.474069707241e-08 
    Momentum: 
-      |mRes|_2  = 2.879190684659e-06 
+      |mRes|_2  = 2.608835871344e-06 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.050442 sec)
+Saving output ... done (0.049379 sec)
 --------------------------------------------------------------------------
 ================================ STEP 17 =================================
 --------------------------------------------------------------------------
 Current time        : 0.05178407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.736067867733e+00 
+  0 SNES Function norm 5.735443334513e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 1.848849215815e+00 
-  1 MMFD   ||F||/||F0||=3.223200e-01 
+  1 SNES Function norm 1.848773608815e+00 
+  1 MMFD   ||F||/||F0||=3.223419e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  2 SNES Function norm 6.916288711145e-01 
-  2 MMFD   ||F||/||F0||=1.205754e-01 
+  2 SNES Function norm 6.910822060079e-01 
+  2 MMFD   ||F||/||F0||=1.204932e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  3 SNES Function norm 1.049710715732e-02 
-  3 MMFD   ||F||/||F0||=1.830018e-03 
+  3 SNES Function norm 1.033291159407e-02 
+  3 MMFD   ||F||/||F0||=1.801589e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  4 SNES Function norm 6.703942592621e-06 
+  4 SNES Function norm 6.159741865363e-06 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 4
-SNES solution time      : 0.045843 (sec)
+SNES solution time      : 0.04554 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 6.820804303870e-11 
-      |Div|_2   = 2.852964681295e-10 
+      |Div|_inf = 8.143740718834e-11 
+      |Div|_2   = 2.538393297766e-10 
    Momentum: 
-      |mRes|_2  = 6.703942586550e-06 
+      |mRes|_2  = 6.159741860133e-06 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.051005 sec)
+Saving output ... done (0.049239 sec)
 --------------------------------------------------------------------------
 ================================ STEP 18 =================================
 --------------------------------------------------------------------------
 Current time        : 0.05678407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.246388509673e+00 
+  0 SNES Function norm 6.245546574406e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 6.781229166837e-01 
-  1 MMFD   ||F||/||F0||=1.085624e-01 
+  1 SNES Function norm 6.778625564053e-01 
+  1 MMFD   ||F||/||F0||=1.085353e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 1.709210911903e-02 
-  2 MMFD   ||F||/||F0||=2.736319e-03 
+  2 SNES Function norm 1.653095012918e-02 
+  2 MMFD   ||F||/||F0||=2.646838e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  3 SNES Function norm 2.888991757249e-05 
+  3 SNES Function norm 2.813956058603e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 3
-SNES solution time      : 0.035928 (sec)
+SNES solution time      : 0.034758 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 1.696206301696e-08 
-      |Div|_2   = 2.996969220589e-08 
+      |Div|_inf = 2.047125586657e-08 
+      |Div|_2   = 3.839041494174e-08 
    Momentum: 
-      |mRes|_2  = 2.888990202757e-05 
+      |mRes|_2  = 2.813953439826e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.046788 sec)
+Saving output ... done (0.051152 sec)
 --------------------------------------------------------------------------
 ================================ STEP 19 =================================
 --------------------------------------------------------------------------
 Current time        : 0.06178407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.988560682141e+00 
+  0 SNES Function norm 5.987602508715e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 1.457644986344e+00 
-  1 MMFD   ||F||/||F0||=2.434049e-01 
+  1 SNES Function norm 1.457960213160e+00 
+  1 MMFD   ||F||/||F0||=2.434965e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 6.739596076267e-01 
-  2 MMFD   ||F||/||F0||=1.125412e-01 
+  2 SNES Function norm 6.731792865416e-01 
+  2 MMFD   ||F||/||F0||=1.124289e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  3 SNES Function norm 1.938847421615e-02 
-  3 MMFD   ||F||/||F0||=3.237585e-03 
+  3 SNES Function norm 1.910378598508e-02 
+  3 MMFD   ||F||/||F0||=3.190557e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  4 SNES Function norm 4.341590815546e-05 
+  4 SNES Function norm 4.220935644539e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 4
-SNES solution time      : 0.046461 (sec)
+SNES solution time      : 0.045069 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 7.877890053720e-09 
-      |Div|_2   = 2.357127246209e-08 
+      |Div|_inf = 7.654155103638e-09 
+      |Div|_2   = 2.306079649726e-08 
    Momentum: 
-      |mRes|_2  = 4.341590175683e-05 
+      |mRes|_2  = 4.220935014583e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.048395 sec)
+Saving output ... done (0.051015 sec)
 --------------------------------------------------------------------------
 ================================ STEP 20 =================================
 --------------------------------------------------------------------------
 Current time        : 0.06678407 [Myr] 
 Tentative time step : 0.00500000 [Myr] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 5.937821315151e+00 
+  0 SNES Function norm 5.937140980857e+00 
   0 PICARD ||F||/||F0||=1.000000e+00 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 1
-  1 SNES Function norm 9.611396461200e-01 
-  1 MMFD   ||F||/||F0||=1.618674e-01 
+  1 SNES Function norm 9.609291051357e-01 
+  1 MMFD   ||F||/||F0||=1.618505e-01 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  2 SNES Function norm 4.601938482418e-01 
-  2 MMFD   ||F||/||F0||=7.750214e-02 
+  2 SNES Function norm 4.591478766526e-01 
+  2 MMFD   ||F||/||F0||=7.733484e-02 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 3
-  3 SNES Function norm 2.260835210129e-02 
-  3 MMFD   ||F||/||F0||=3.807516e-03 
+  3 SNES Function norm 2.241609467967e-02 
+  3 MMFD   ||F||/||F0||=3.775571e-03 
   Linear js_ solve converged due to CONVERGED_RTOL iterations 6
-  4 SNES Function norm 9.580723568444e-05 
+  4 SNES Function norm 9.314883787513e-05 
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
 Number of iterations    : 4
-SNES solution time      : 0.047746 (sec)
+SNES solution time      : 0.050542 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 8.632232820020e-08 
-      |Div|_2   = 1.566984698708e-07 
+      |Div|_inf = 8.313036506122e-08 
+      |Div|_2   = 1.492936179555e-07 
    Momentum: 
-      |mRes|_2  = 9.580710753949e-05 
+      |mRes|_2  = 9.314871823542e-05 
 --------------------------------------------------------------------------
 Actual time step : 0.00500 [Myr] 
 --------------------------------------------------------------------------
-Saving output ... done (0.046481 sec)
+Saving output ... done (0.049688 sec)
 --------------------------------------------------------------------------
 =========================== SOLUTION IS DONE! ============================
 --------------------------------------------------------------------------
-Total solution time : 1.75692 (sec) 
+Total solution time : 1.82862 (sec) 
 --------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds viscoplastic regularisation to the rheology model of LaMEM (red item):
<img width="506" alt="Screenshot 2024-02-12 at 23 05 42" src="https://github.com/UniMainzGeo/LaMEM/assets/61824822/599f0a2c-0b12-4a1b-a4f7-31a10ed71c17">

Previous, we could do plasticity regularisation already by specifying the `eta_st` viscosity per phase, which changes the minimum viscosity from its global value (`eta_min`), to a phase-wise value. 
Another possibility is by amending the plasticity yield stress directly:
```math
\tau_y = \tau_y + 2 \eta_{\textrm{vp}} \dot{\varepsilon}_{II}^{\textrm{pl}}
```
where $\tau_y$ is a yield stress, $\eta_{\textrm{vp}}$ a regularisation viscosity, and $\dot{\varepsilon}_{II}^{\textrm{pl}}$ the plastic strainrate. This regularisation was used by [Duretz et al. 2018 ](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2018GC007877), among others. 

This PR adds a new, phase-wise, material parameter to specify this (set to zero by default):
```
eta_vp = 1e19
```

**Comparison of regularisation methods**
The newly added test `/tests/t4_Loc/localization_eta_vp_reg.dat` was used to compare the different formulations, with $\eta_{vp}=10^{21}$ Pas, or  $\eta_{st}=10^{21}$ Pas. Looking at the number of SNES iterations shows that both regularisations reduce the number of iterations, but that the viscoplastic method is slightly more efficient:  
![iter](https://github.com/UniMainzGeo/LaMEM/assets/61824822/684df31a-d825-4a9d-94b8-34019bdc315b)

A table with timings (on an M2 MacBook Pro):
| method | total time [s] |
| ------- | ------------- |
| no regularisation | 392 | 
|eta_st | 82 | 
|eta_vp | 57 | 

A comparison of the 2nd invariant of the strain rate at the end of the simulation for different resolutions for a case that uses the new method using `eta_vp=1e21`.
![vp_reg_comparison](https://github.com/UniMainzGeo/LaMEM/assets/61824822/3408a223-2f17-4182-b6df-545c802f4388)


