### PR TITLE
LaMEM and FastScape surface processes

### DIFF
--- a/LaMEMLib.cpp
+++ b/LaMEMLib.cpp
@@ -1,0 +1,1036 @@
+/*@ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ **
+ **   Project      : LaMEM
+ **   License      : MIT, see LICENSE file for details
+ **   Contributors : Anton Popov, Boris Kaus, see AUTHORS file for complete list
+ **   Organization : Institute of Geosciences, Johannes-Gutenberg University, Mainz
+ **   Contact      : kaus@uni-mainz.de, popov@uni-mainz.de
+ **
+ ** ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ @*/
+//---------------------------------------------------------------------------
+// LAMEM LIBRARY MODE ROUTINE
+//---------------------------------------------------------------------------
+#include "LaMEM.h"
+#include "phase.h"
+#include "dike.h"
+#include "parsing.h"
+#include "scaling.h"
+#include "tssolve.h"
+#include "tools.h"
+#include "fdstag.h"
+#include "bc.h"
+#include "JacRes.h"
+#include "interpolate.h"
+#include "surf.h"
+#include "paraViewOutBin.h"
+#include "paraViewOutSurf.h"
+#include "multigrid.h"
+#include "matrix.h"
+#include "lsolve.h"
+#include "nlsolve.h"
+#include "multigrid.h"
+#include "Tensor.h"
+#include "advect.h"
+#include "marker.h"
+#include "paraViewOutMark.h"
+#include "paraViewOutAVD.h"
+#include "objFunct.h"
+#include "adjoint.h"
+#include "paraViewOutPassiveTracers.h"
+#include "LaMEMLib.h"
+#include "phase_transition.h"
+#include "passive_tracer.h"
+
+// surface process
+#include "fastscape.h"
+
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibMain(void *param,PetscLogStage stages[4])
+{
+	LaMEMLib       lm;
+	RunMode        mode;
+	PetscBool      found;
+	PetscInt       exists;
+	char           str[_str_len_];
+	PetscLogDouble cputime_start, cputime_end;
+
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;       
+
+	// start code
+	ierr = PetscTime(&cputime_start); CHKERRQ(ierr);
+
+	PetscPrintf(PETSC_COMM_WORLD,"-------------------------------------------------------------------------- \n");
+	PetscPrintf(PETSC_COMM_WORLD,"                   Lithosphere and Mantle Evolution Model                   \n");
+	PetscPrintf(PETSC_COMM_WORLD,"     Compiled: Date: %s - Time: %s 	    \n",__DATE__,__TIME__ );
+	PetscPrintf(PETSC_COMM_WORLD,"     Version : 2.1.4 \n");
+	PetscPrintf(PETSC_COMM_WORLD,"-------------------------------------------------------------------------- \n");
+	PetscPrintf(PETSC_COMM_WORLD,"        STAGGERED-GRID FINITE DIFFERENCE CANONICAL IMPLEMENTATION           \n");
+	PetscPrintf(PETSC_COMM_WORLD,"-------------------------------------------------------------------------- \n");
+
+	// read run mode
+	mode = _NORMAL_;
+
+	ierr = PetscOptionsGetCheckString("-mode", str, &found); CHKERRQ(ierr);
+
+	if(found)
+	{
+		if     (!strcmp(str, "normal"))    mode = _NORMAL_;
+		else if(!strcmp(str, "restart"))   mode = _RESTART_;
+		else if(!strcmp(str, "dry_run"))   mode = _DRY_RUN_;
+		else if(!strcmp(str, "save_grid")) mode = _SAVE_GRID_;
+		else SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_USER, "Incorrect run mode type: %s", str);
+	}
+
+	// cancel restart if no database is available
+	if(mode == _RESTART_)
+	{
+		ierr = DirCheck("./restart", &exists); CHKERRQ(ierr);
+
+		if(!exists)
+		{
+			SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_USER, "No restart database available (check -mode option)");
+		}
+	}
+
+	//===========
+	// INITIALIZE
+	//===========
+
+	// clear
+	ierr = PetscMemzero(&lm, sizeof(LaMEMLib)); CHKERRQ(ierr);
+
+	// setup cross-references between library objects
+	ierr = LaMEMLibSetLinks(&lm); CHKERRQ(ierr);
+
+	if(mode == _SAVE_GRID_)
+	{
+		// save grid & exit
+		ierr = LaMEMLibSaveGrid(&lm); CHKERRQ(ierr);
+
+		PetscFunctionReturn(0);
+	}
+	if(mode == _NORMAL_ || mode == _DRY_RUN_)
+	{
+		// create library objects
+		ierr = LaMEMLibCreate(&lm, param); CHKERRQ(ierr);
+	}
+	else if(mode == _RESTART_)
+	{
+		// open restart database
+		ierr = LaMEMLibLoadRestart(&lm); CHKERRQ(ierr);
+	}
+
+	//======
+	// SOLVE
+	//======
+
+	if(mode == _DRY_RUN_)
+	{
+		// compute initial residual, output & stop
+		ierr = LaMEMLibDryRun(&lm); CHKERRQ(ierr);
+	}
+	else if(mode == _NORMAL_ || mode == _RESTART_)
+	{
+		// solve coupled nonlinear equations
+		ierr = LaMEMLibSolve(&lm, param,stages); CHKERRQ(ierr);
+	}
+
+	// destroy library objects
+	ierr = LaMEMLibDestroy(&lm); CHKERRQ(ierr);
+
+	PetscTime(&cputime_end);
+
+	PetscPrintf(PETSC_COMM_WORLD, "Total solution time : %g (sec) \n", cputime_end - cputime_start);
+	PetscPrintf(PETSC_COMM_WORLD, "--------------------------------------------------------------------------\n");
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibCreate(LaMEMLib *lm, void *param )
+{
+	FB *fb;
+
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	if(param) param = NULL;
+
+	// load input file
+	ierr = FBLoad(&fb, PETSC_TRUE); CHKERRQ(ierr);
+
+	// create scaling object
+	ierr = ScalingCreate(&lm->scal, fb, PETSC_TRUE);CHKERRQ(ierr);
+
+	// create time stepping object
+	ierr = TSSolCreate(&lm->ts, fb); 				CHKERRQ(ierr);
+
+	// create parallel grid
+	ierr = FDSTAGCreate(&lm->fs, fb); 				CHKERRQ(ierr);
+
+	// create material database
+	ierr = DBMatCreate(&lm->dbm, fb, PETSC_TRUE); 	CHKERRQ(ierr);
+
+	// create free surface grid
+	ierr = FreeSurfCreate(&lm->surf, fb); 			CHKERRQ(ierr);
+
+	// create boundary condition context
+	ierr = BCCreate(&lm->bc, fb); 					CHKERRQ(ierr);
+
+	// create residual & Jacobian evaluation context
+	ierr = JacResCreate(&lm->jr, fb); 				CHKERRQ(ierr);
+
+	// create dike database
+	ierr = DBDikeCreate(&lm->dbdike, &lm->dbm, fb, &lm->jr, PETSC_TRUE);   CHKERRQ(ierr);
+
+	// initialize arrays for dynamic phase transition
+	ierr = DynamicPhTr_Init(&lm->jr);			CHKERRQ(ierr);
+
+	// create advection context
+	ierr = ADVCreate(&lm->actx, fb); 				CHKERRQ(ierr);
+
+	// create passive tracers
+	ierr = ADVPtrPassive_Tracer_create(&lm->actx,fb);			CHKERRQ(ierr);
+
+	// create output object for all requested output variables
+	ierr = PVOutCreate(&lm->pvout, fb); 			CHKERRQ(ierr);
+
+	// create output object for the free surface
+	ierr = PVSurfCreate(&lm->pvsurf, fb); 			CHKERRQ(ierr);
+
+	// create output object for the markers - for debugging
+	ierr = PVMarkCreate(&lm->pvmark, fb); 			CHKERRQ(ierr);
+
+	// create output object for the passive tracers
+	ierr = PVPtrCreate(&lm->pvptr, fb);              CHKERRQ(ierr);
+
+	// AVD output driver
+	ierr = PVAVDCreate(&lm->pvavd, fb); 			CHKERRQ(ierr);
+
+	// destroy file buffer
+	ierr = FBDestroy(&fb); CHKERRQ(ierr);
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibSaveGrid(LaMEMLib *lm)
+{
+	FB *fb;
+
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	// load input file
+	ierr = FBLoad(&fb, PETSC_TRUE); CHKERRQ(ierr);
+
+	// create scaling object
+	ierr = ScalingCreate(&lm->scal, fb, PETSC_TRUE); CHKERRQ(ierr);
+
+	// create parallel grid
+	ierr = FDSTAGCreate(&lm->fs, fb); CHKERRQ(ierr);
+
+	// save processor partitioning
+	ierr = FDSTAGSaveGrid(&lm->fs); CHKERRQ(ierr);
+
+	// destroy parallel grid
+	ierr = FDSTAGDestroy(&lm->fs); CHKERRQ(ierr);
+
+	// destroy file buffer
+	ierr = FBDestroy(&fb); CHKERRQ(ierr);
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibLoadRestart(LaMEMLib *lm)
+{
+	FB              *fb;
+	FILE            *fp;
+	PetscLogDouble  t;
+	PetscMPIInt     rank;
+	PetscBool       found;
+	char            restartFileName[_str_len_], *fileName;
+
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	PrintStart(&t, "Loading restart database", NULL);
+
+	// get MPI processor rank
+	MPI_Comm_rank(PETSC_COMM_WORLD, &rank);
+
+	// compile restart file name
+	asprintf(&fileName, "./restart/rdb.%1.8lld.dat", (LLD)rank);
+
+	// open restart file for reading in binary mode
+	fp = fopen(fileName, "rb");
+
+	if(fp == NULL)
+	{
+		SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_USER, "Cannot open restart file %s\n", fileName);
+	}
+
+	// read LaMEM library database
+	fread(lm, sizeof(LaMEMLib), 1, fp);
+
+	// setup cross-references between library objects
+	ierr = LaMEMLibSetLinks(lm); CHKERRQ(ierr);
+
+	// staggered grid
+	ierr = FDSTAGReadRestart(&lm->fs, fp); CHKERRQ(ierr);
+
+	// free surface
+	ierr = FreeSurfReadRestart(&lm->surf, fp); CHKERRQ(ierr);
+
+	// boundary conditions context
+	ierr = BCReadRestart(&lm->bc, fp); CHKERRQ(ierr);
+
+	// solution variables
+	ierr = JacResReadRestart(&lm->jr, fp); CHKERRQ(ierr);
+
+	// markers
+	ierr = ADVReadRestart(&lm->actx, fp); CHKERRQ(ierr);
+
+	// passive tracers read restart
+	ierr = ReadPassive_Tracers(&lm->actx,fp); CHKERRQ(ierr);
+
+	// main output driver
+	ierr = PVOutCreateData(&lm->pvout); CHKERRQ(ierr);
+
+	// surface output driver
+	ierr = PVSurfCreateData(&lm->pvsurf); CHKERRQ(ierr);
+
+	// arrays for dynamic NotInAir phase_trans
+	ierr = DynamicPhTr_ReadRestart(&lm->jr, fp); CHKERRQ(ierr);
+
+	// read from input file, create arrays for dynamic diking, and read from restart file
+	ierr = DynamicDike_ReadRestart(&lm->dbdike, &lm->dbm, &lm->jr, &lm->ts, fp);  CHKERRQ(ierr);
+ 
+	// close temporary restart file
+	fclose(fp);
+
+	// free space
+	free(fileName);
+
+	// check whether restart input file is specified
+	ierr = PetscOptionsGetCheckString("-RestartParamFile", restartFileName, &found); CHKERRQ(ierr);
+
+	if(found == PETSC_TRUE)
+	{
+		// load restart input file
+		ierr = FBLoad(&fb, PETSC_TRUE, restartFileName); CHKERRQ(ierr);
+
+		// override material database
+		ierr = DBMatCreate(&lm->dbm, fb, PETSC_TRUE); 	CHKERRQ(ierr);
+
+		// destroy file buffer
+		ierr = FBDestroy(&fb); CHKERRQ(ierr);
+	}
+
+	PrintDone(t);
+
+	PetscFunctionReturn(0);
+
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibSaveRestart(LaMEMLib *lm)
+{
+	// save new restart database, then delete the original
+
+	FILE           *fp;
+	PetscMPIInt    rank;
+	char           *fileNameTmp;
+	PetscLogDouble t;
+
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	if(!TSSolIsRestart(&lm->ts)) PetscFunctionReturn(0);
+
+	PrintStart(&t, "Saving restart database", NULL);
+
+	// get MPI processor rank
+	MPI_Comm_rank(PETSC_COMM_WORLD, &rank);
+
+	// compile actual & temporary restart file name
+	asprintf(&fileNameTmp, "./restart-tmp/rdb.%1.8lld.dat", (LLD)rank);
+
+	// create temporary restart directory
+	ierr = DirMake("./restart-tmp"); CHKERRQ(ierr);
+
+	// open temporary restart file for writing in binary mode
+	fp = fopen(fileNameTmp, "wb");
+
+	if(fp == NULL)
+	{
+		SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_USER, "Cannot open restart file %s\n", fileNameTmp);
+	}
+
+	// write LaMEM library database
+	fwrite(lm, sizeof(LaMEMLib), 1, fp);
+
+	// staggered grid
+	ierr = FDSTAGWriteRestart(&lm->fs, fp); CHKERRQ(ierr);
+
+	// free surface
+	ierr = FreeSurfWriteRestart(&lm->surf, fp); CHKERRQ(ierr);
+
+	// boundary conditions context
+	ierr = BCWriteRestart(&lm->bc, fp); CHKERRQ(ierr);
+
+	// solution variables
+	ierr = JacResWriteRestart(&lm->jr, fp); CHKERRQ(ierr);
+
+	// markers
+	ierr = ADVWriteRestart(&lm->actx, fp); CHKERRQ(ierr);
+
+	// passive tracers
+	ierr = Passive_Tracer_WriteRestart(&lm->actx, fp); CHKERRQ(ierr);
+
+	// dynamic phase transition 
+	ierr = DynamicPhTr_WriteRestart(&lm->jr, fp); CHKERRQ(ierr);
+
+	// dynamic dike 
+	ierr = DynamicDike_WriteRestart(&lm->jr, fp); CHKERRQ(ierr);
+
+	// close temporary restart file
+	fclose(fp);
+
+	// delete existing restart database
+	ierr = LaMEMLibDeleteRestart(); CHKERRQ(ierr);
+
+	// push temporary database to actual
+	ierr = DirRename("./restart-tmp", "./restart");
+
+	// free space
+	free(fileNameTmp);
+
+	PrintDone(t);
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibDeleteRestart()
+{
+	// delete existing restart database
+	PetscMPIInt  rank;
+	int          status;
+	PetscInt     exists;
+	char        *fileName;
+
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	// get MPI processor rank
+	MPI_Comm_rank(PETSC_COMM_WORLD, &rank);
+
+	asprintf(&fileName, "./restart/rdb.%1.8lld.dat", (LLD)rank);
+
+	// check for existing restart database
+	ierr = DirCheck("./restart", &exists); CHKERRQ(ierr);
+
+	if(exists)
+	{
+		// delete existing database
+		status = remove(fileName);
+
+		if(status && errno != ENOENT)
+		{
+			SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_USER, "Failed to delete file %s", fileName);
+		}
+
+		ierr = DirRemove("./restart"); CHKERRQ(ierr);
+	}
+
+	// free space
+	free(fileName);
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibDestroy(LaMEMLib *lm)
+{
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	ierr = FDSTAGDestroy  (&lm->fs);     CHKERRQ(ierr);
+	ierr = FreeSurfDestroy(&lm->surf);   CHKERRQ(ierr);
+	ierr = BCDestroy      (&lm->bc);     CHKERRQ(ierr);
+	ierr = JacResDestroy  (&lm->jr);     CHKERRQ(ierr);
+	ierr = ADVPtrDestroy  (&lm->actx);   CHKERRQ(ierr);
+	ierr = ADVDestroy     (&lm->actx);   CHKERRQ(ierr);
+	ierr = PVOutDestroy   (&lm->pvout);  CHKERRQ(ierr);
+	ierr = PVSurfDestroy  (&lm->pvsurf); CHKERRQ(ierr);
+
+	ierr = DynamicPhTrDestroy (&lm->dbm); CHKERRQ(ierr);
+	ierr = DynamicDike_Destroy(&lm->jr); CHKERRQ(ierr);
+
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibSetLinks(LaMEMLib *lm)
+{
+	//======================================================================
+	// LaMEM library object initialization sequence
+	//
+	//                         Scaling
+	//                            |
+	//                          TSSol
+	//                            |
+	//                          DBMat/DBPropDike
+	//                            |
+	//                         FDSTAG
+	//                            |
+	//                         FreeSurf
+	//                            |
+	//                          BCCtx
+	//                            |
+	//                          JacRes
+	//                            |
+	//                          AdvCtx
+	//                            |
+	//              -----------------------------
+	//              |       |          |        |
+	//            PVOut   PVSurf     PVMark   PVAVD
+	//======================================================================
+
+	// setup cross-references between library objects
+
+	// ... This is the house that Jack built ...
+
+	PetscFunctionBeginUser;
+	// TSSol
+	lm->ts.scal     = &lm->scal;
+	// DBMat
+	lm->dbm.scal    = &lm->scal;
+	// FDSTAG
+	lm->fs.scal     = &lm->scal;
+	// FreeSurf
+	lm->surf.jr     = &lm->jr;
+	// BCCtx
+	lm->bc.scal     = &lm->scal;
+	lm->bc.ts       = &lm->ts;
+	lm->bc.fs       = &lm->fs;
+	lm->bc.dbm      = &lm->dbm;
+	lm->bc.jr       = &lm->jr;
+	// JacRes
+	lm->jr.scal     = &lm->scal;
+	lm->jr.ts       = &lm->ts;
+	lm->jr.fs       = &lm->fs;
+	lm->jr.surf     = &lm->surf;
+	lm->jr.bc       = &lm->bc;
+	lm->jr.dbm      = &lm->dbm;
+	lm->jr.dbdike   = &lm->dbdike;
+	// AdvCtx
+	lm->actx.fs     = &lm->fs;
+	lm->actx.jr     = &lm->jr;
+	lm->actx.surf   = &lm->surf;
+	lm->actx.dbm    = &lm->dbm;
+	lm->actx.Ptr    = &lm->Ptr;
+	// PVOut
+	lm->pvout.jr    = &lm->jr;
+	// PVSurf
+	lm->pvsurf.surf = &lm->surf;
+	// PVMark
+	lm->pvmark.actx = &lm->actx;
+	// PVPTR
+	lm->pvptr.actx  = &lm->actx;
+	// PVAVD
+	lm->pvavd.actx  = &lm->actx;
+
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibSaveOutput(LaMEMLib *lm)
+{
+	//==================
+	// Save data to disk
+	//==================
+
+	Scaling        *scal;
+	TSSol          *ts;
+	PetscScalar    time;
+	PetscInt       bgPhase, step;
+	char           *dirName;
+	PetscLogDouble t;
+
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	scal = &lm->scal;
+	ts   = &lm->ts;
+
+	if(!TSSolIsOutput(ts)) PetscFunctionReturn(0);
+
+	PrintStart(&t, "Saving output", NULL);
+
+	time    = ts->time*scal->time;
+	step    = ts->istep;
+	bgPhase = lm->actx.bgPhase;
+
+
+
+	// create directory (encode current time & step number)
+	asprintf(&dirName, "Timestep_%1.8lld_%1.8e", (LLD)step, time);
+
+	// create output directory
+	ierr = DirMake(dirName); CHKERRQ(ierr);
+
+	// AVD phase output
+	ierr = PVAVDWriteTimeStep(&lm->pvavd, dirName, time); CHKERRQ(ierr);
+
+	// grid ParaView output
+	ierr = PVOutWriteTimeStep(&lm->pvout, dirName, time); CHKERRQ(ierr);
+
+	// free surface ParaView output
+	ierr = PVSurfWriteTimeStep(&lm->pvsurf, dirName, time); CHKERRQ(ierr);
+
+	// marker ParaView output
+	ierr = PVMarkWriteTimeStep(&lm->pvmark, dirName, time); CHKERRQ(ierr);
+
+	// compute and output effective permeability
+	ierr = JacResGetPermea(&lm->jr, bgPhase, step, lm->pvout.outfile); CHKERRQ(ierr);
+
+	// passive tracers paraview output
+	if(ISRankZero(PETSC_COMM_WORLD))
+	{
+		// save .dat files// binary of passive tracers
+		ierr = PVPtrWriteTimeStep(&lm->pvptr, dirName, time); CHKERRQ(ierr);
+
+	}
+	// clean up
+	free(dirName);
+
+	PrintDone(t);
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibSolve(LaMEMLib *lm, void *param, PetscLogStage stages[4])
+{
+	PMat           pm;     // preconditioner matrix    (to be removed!)
+	PCStokes       pc;     // Stokes preconditioner    (to be removed!)
+	NLSol          nl;     // nonlinear solver context (to be removed!)
+ 	AdjGrad        aop;    // Adjoint options          (to be removed!)
+	SNES           snes;   // PETSc nonlinear solver
+	PetscInt       restart;
+	PetscLogDouble t;
+
+
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	// create Stokes preconditioner, matrix and nonlinear solver
+	ierr = PMatCreate(&pm, &lm->jr);    CHKERRQ(ierr);
+	ierr = PCStokesCreate(&pc, pm);     CHKERRQ(ierr);
+	ierr = NLSolCreate(&nl, pc, &snes); CHKERRQ(ierr);
+
+	//==============
+	// INITIAL GUESS
+	//==============
+	PetscCall(PetscLogStagePush(stages[0])); /* Start profiling stage*/
+
+	ierr = LaMEMLibInitGuess(lm, snes); CHKERRQ(ierr);
+
+	PetscCall(PetscLogStagePop()); /* Stop profiling stage*/
+
+	if (param)
+	{
+		ierr = AdjointCreate(&aop, &lm->jr, (ModParam *)param); CHKERRQ(ierr);
+	}
+
+	//===============
+	// TIME STEP LOOP
+	//===============
+
+	while(!TSSolIsDone(&lm->ts))
+	{
+		//====================================
+		//	NONLINEAR THERMO-MECHANICAL SOLVER
+		//====================================
+
+		// apply phase transitions on particles
+		ierr = Phase_Transition(&lm->actx); CHKERRQ(ierr);
+		
+		// initialize boundary constraint vectors
+		ierr = BCApply(&lm->bc); CHKERRQ(ierr);
+
+	
+		// initialize temperature
+		ierr = JacResInitTemp(&lm->jr); CHKERRQ(ierr);
+
+		// compute elastic parameters
+		ierr = JacResGetI2Gdt(&lm->jr); CHKERRQ(ierr);
+
+		// solve nonlinear equation system with SNES
+		PetscTime(&t);
+
+		PetscCall(PetscLogStagePush(stages[1])); /* Start profiling stage*/
+
+		ierr = SNESSolve(snes, NULL, lm->jr.gsol); CHKERRQ(ierr);
+
+		PetscCall(PetscLogStagePop()); /* Stop profiling stage*/
+		// print analyze convergence/divergence reason & iteration count
+		ierr = SNESPrintConvergedReason(snes, t); CHKERRQ(ierr);
+
+		// view nonlinear residual
+		ierr = JacResViewRes(&lm->jr); CHKERRQ(ierr);
+
+		// Compute adjoint gradients every TS
+		if (param)
+		{
+			
+			ModParam      *IOparam;
+			IOparam       = (ModParam *)param;	
+			if (IOparam->use == _adjointgradients_ || IOparam->use == _gradientdescent_ || IOparam->use == _inversion_ )
+			{	/* 	Compute the adjoint gradients 
+				 	
+					This is done here, as the adjoint should be cmputed with the current residual that does not take advection etc.
+					into account. It does compute it every dt; one can perhaps only activate it for the last dt.
+				*/
+				ierr = AdjointObjectiveAndGradientFunction(&aop, &lm->jr, &nl, (ModParam *)param, snes, &lm->surf); CHKERRQ(ierr);
+			}
+		}
+
+		//==========================================
+		// MARKER & FREE SURFACE ADVECTION + EROSION
+		//==========================================
+
+		PetscCall(PetscLogStagePush(stages[2])); /* Start profiling stage*/
+
+		// calculate current time step
+		ierr = ADVSelectTimeStep(&lm->actx, &restart); CHKERRQ(ierr);
+		
+		// restart if fixed time step is larger than CFLMAX
+		if(restart) continue;
+
+		// advect free surface
+		ierr = FreeSurfAdvect(&lm->surf); CHKERRQ(ierr);
+
+		// advect markers
+		ierr = ADVAdvect(&lm->actx); CHKERRQ(ierr);
+
+		// apply background strain-rate "DWINDLAR" BC (Bob Shaw "Ship of Strangers")
+		ierr = BCStretchGrid(&lm->bc); CHKERRQ(ierr);
+
+		// exchange markers between the processors (after mesh advection)
+		ierr = ADVExchange(&lm->actx); CHKERRQ(ierr);
+
+		// Advect Passive tracers
+		ierr = ADVAdvectPassiveTracer(&lm->actx); CHKERRQ(ierr);
+
+		PetscCall(PetscLogStagePop()); /* Stop profiling stage*/
+
+		int SurfaceMode;
+		SurfaceMode = SURFACE;
+
+		if( 1 == SurfaceMode )
+		// using LaMEM original code to calculate topography
+		{
+			PetscPrintf(PETSC_COMM_WORLD, "\n Calculating surface process through LaMEM original code \n");
+			// apply erosion to the free surface
+			ierr = FreeSurfAppErosion(&lm->surf); CHKERRQ(ierr);
+
+			// apply sedimentation to the free surface
+			ierr = FreeSurfAppSedimentation(&lm->surf); CHKERRQ(ierr);
+		}
+
+		if( 2 == SurfaceMode)
+		// Using FastScape to calculate topography
+		{
+			PetscPrintf(PETSC_COMM_WORLD, "\n Calculating surface process through FastScape \n");
+			ierr = fastscape(&lm->surf, &lm->actx); CHKERRQ(ierr);
+			PetscPrintf(PETSC_COMM_WORLD, "\n FastScape Done \n");
+		}
+
+
+		// remap markers onto (stretched) grid
+		ierr = ADVRemap(&lm->actx); CHKERRQ(ierr);
+
+		// update phase ratios taking into account actual free surface position
+		ierr = FreeSurfGetAirPhaseRatio(&lm->surf); CHKERRQ(ierr);
+
+		//==================
+		// Save data to disk
+		//==================
+	
+		// update time stamp and counter
+		ierr = TSSolStepForward(&lm->ts); CHKERRQ(ierr);
+
+		PetscCall(PetscLogStagePush(stages[3])); /* Start profiling stage*/
+
+		// grid & marker output
+		ierr = LaMEMLibSaveOutput(lm); CHKERRQ(ierr);
+
+		PetscCall(PetscLogStagePop()); /* Stop profiling stage*/
+
+		// restart database
+		ierr = LaMEMLibSaveRestart(lm); CHKERRQ(ierr);
+
+	}
+
+	//======================
+	// END OF TIME STEP LOOP
+	//======================
+
+	if (param)
+	{
+
+		ModParam      *IOparam;
+		IOparam       = (ModParam *)param;
+
+		if(IOparam->use == _syntheticforwardrun_)
+		{	// Assume this as a forward simulation and save the solution vector
+	 		//VecDuplicate(lm->jr.gsol, &IOparam->xini);
+			//VecCopy(lm->jr.gsol, IOparam->xini);
+		}
+
+		ierr = AdjointDestroy (&aop,  IOparam);  	CHKERRQ(ierr);
+
+	}
+
+	// destroy objects
+	ierr = PCStokesDestroy(pc);    			CHKERRQ(ierr);
+	ierr = PMatDestroy    (pm);    			CHKERRQ(ierr);
+	ierr = SNESDestroy    (&snes); 			CHKERRQ(ierr);
+	ierr = NLSolDestroy   (&nl);   			CHKERRQ(ierr);
+
+	// save marker database
+	ierr = ADVMarkSave(&lm->actx); CHKERRQ(ierr);
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibDryRun(LaMEMLib *lm)
+{
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	// initialize boundary constraint vectors
+	ierr = BCApply(&lm->bc); CHKERRQ(ierr);
+
+	// initialize temperature
+	ierr = JacResInitTemp(&lm->jr); CHKERRQ(ierr);
+
+	// compute inverse elastic parameters (dependent on dt)
+	ierr = JacResGetI2Gdt(&lm->jr); CHKERRQ(ierr);
+
+	// evaluate initial residual
+	ierr = JacResFormResidual(&lm->jr, lm->jr.gsol, lm->jr.gres); CHKERRQ(ierr);
+
+	// save output for inspection
+	ierr = LaMEMLibSaveOutput(lm); CHKERRQ(ierr);
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibInitGuess(LaMEMLib *lm, SNES snes)
+{
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	PetscLogDouble t;
+
+	// initialize boundary constraint vectors
+	ierr = BCApply(&lm->bc); CHKERRQ(ierr);
+
+	// initialize temperature
+	ierr = JacResInitTemp(&lm->jr); CHKERRQ(ierr);
+
+	// solve for steady-state temperature (if requested)
+	ierr = LaMEMLibDiffuseTemp(lm); CHKERRQ(ierr);
+
+	// initialize pressure
+	ierr = JacResInitPres(&lm->jr,&lm->ts); CHKERRQ(ierr);
+
+	// lithostatic pressure initializtaion
+	ierr = JacResInitLithPres(&lm->jr, &lm->actx, &lm->ts); CHKERRQ(ierr);
+
+	// compute inverse elastic parameters (dependent on dt)
+	ierr = JacResGetI2Gdt(&lm->jr); CHKERRQ(ierr);
+
+	if(lm->jr.ctrl.initGuess)
+	{
+		PetscPrintf(PETSC_COMM_WORLD, "============================== INITIAL GUESS =============================\n");
+		PetscPrintf(PETSC_COMM_WORLD, "--------------------------------------------------------------------------\n");
+
+		// solve nonlinear equation system with SNES
+		PetscTime(&t);
+
+		ierr = SNESSolve(snes, NULL, lm->jr.gsol); CHKERRQ(ierr);
+
+		// print analyze convergence/divergence reason & iteration count
+		ierr = SNESPrintConvergedReason(snes, t); CHKERRQ(ierr);
+
+		// view nonlinear residual
+		ierr = JacResViewRes(&lm->jr); CHKERRQ(ierr);
+
+		// switch flag
+		lm->jr.ctrl.initGuess = 0;
+	}
+	else
+	{
+		// evaluate initial residual
+		ierr = JacResFormResidual(&lm->jr, lm->jr.gsol, lm->jr.gres); CHKERRQ(ierr);
+	}
+
+	// save output for inspection
+	ierr = LaMEMLibSaveOutput(lm); CHKERRQ(ierr);
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibDiffuseTemp(LaMEMLib *lm)
+{
+	JacRes         *jr;
+	TSSol          *ts;
+	Controls       *ctrl;
+	AdvCtx         *actx;
+	PetscLogDouble t;
+	PetscScalar    diff_step;
+	PetscInt       i, num_steps;
+
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	// access context
+	ts       = &lm->ts; 
+	jr      = &lm->jr;
+	ctrl    = &jr->ctrl;
+	actx    = &lm->actx;
+
+	// check for infinite diffusion
+	if (ctrl->actTemp && ctrl->actSteadyTemp && ts->istep==0)
+	{
+		PrintStart(&t,"Computing steady-state temperature distribution", NULL);
+
+		// ignore existing temperature initialization
+		ierr = VecZeroEntries(jr->lT); CHKERRQ(ierr);
+		ierr = JacResApplyTempBC(jr); CHKERRQ(ierr);
+
+		// compute steady-state temperature distribution
+		ierr = LaMEMLibSolveTemp(lm, 0.0); CHKERRQ(ierr);
+
+		// overwrite markers where T(phase) is set
+		ierr = ADVMarkSetTempPhase(actx); CHKERRQ(ierr);
+
+		// project temperature from markers to grid
+		ierr = ADVProjHistMarkToGrid(actx); CHKERRQ(ierr);
+
+		// initialize temperature
+		ierr = JacResInitTemp(&lm->jr); CHKERRQ(ierr);
+		
+		PrintDone(t);
+	}
+
+	// check for additional limited diffusion
+	if (ctrl->actTemp && ctrl->steadyTempStep && ts->istep==0)
+	{
+		PrintStart(&t,"Diffusing temperature", NULL);
+
+		diff_step = ctrl->steadyTempStep;
+		num_steps = 1;
+
+		if (ctrl->steadyNumStep)
+		{
+			num_steps = ctrl->steadyNumStep;
+			diff_step = diff_step/((PetscScalar) num_steps);
+		}
+		
+		for(i=0;i<num_steps;i++)
+		{
+			// diffuse
+			ierr = LaMEMLibSolveTemp(lm, diff_step); CHKERRQ(ierr);
+
+			// reset temperature in anomalous phases every step
+			if (ctrl->actHeatRech > 1)
+			{
+				// overwrite markers where T(phase) is set
+				ierr = ADVMarkSetTempPhase(actx); CHKERRQ(ierr);
+
+				// project temperature from markers to grid
+				ierr = ADVProjHistMarkToGrid(actx); CHKERRQ(ierr);
+	
+				// initialize temperature
+				ierr = JacResInitTemp(&lm->jr); CHKERRQ(ierr);
+			}
+		}
+
+		// reset Temperature in anomalous phase
+		if (ctrl->actHeatRech)
+		{
+			// overwrite markers where T(phase) is set
+			ierr = ADVMarkSetTempPhase(actx); CHKERRQ(ierr);
+
+			// project temperature from markers to grid
+			ierr = ADVProjHistMarkToGrid(actx); CHKERRQ(ierr);
+	
+			// initialize temperature
+			ierr = JacResInitTemp(&lm->jr); CHKERRQ(ierr);
+		}
+		
+		PrintDone(t);		
+	}
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode LaMEMLibSolveTemp(LaMEMLib *lm, PetscScalar dt)
+{
+	JacRes         *jr;
+	AdvCtx         *actx;
+	KSP            tksp;
+	
+	PetscErrorCode ierr;
+	PetscFunctionBeginUser;
+
+	// access context
+	jr   = &lm->jr;
+	actx = &lm->actx;
+	
+	// create temperature diffusion solver
+	ierr = KSPCreate(PETSC_COMM_WORLD, &tksp); CHKERRQ(ierr);
+
+	// enable geometric multigrid
+	PetscCall(KSPSetDM(tksp, jr->DA_T));
+	PetscCall(KSPSetDMActive(tksp, PETSC_FALSE));
+
+	// set options
+	ierr = KSPSetOptionsPrefix(tksp,"its_");   CHKERRQ(ierr);
+	ierr = KSPSetFromOptions(tksp);            CHKERRQ(ierr);
+
+	// compute matrix and rhs
+	// STEADY STATE solution is activated by setting time step to zero
+	ierr = JacResGetTempRes(jr, dt); CHKERRQ(ierr);
+	ierr = JacResGetTempMat(jr, dt); CHKERRQ(ierr);
+
+	// solve linear system
+	ierr = KSPSetOperators(tksp, jr->Att, jr->Att); CHKERRQ(ierr);
+	ierr = KSPSetUp(tksp);                          CHKERRQ(ierr);
+	ierr = KSPSolve(tksp, jr->ge, jr->dT);          CHKERRQ(ierr);
+
+	// destroy initial temperature solver
+	ierr = KSPDestroy(&tksp); CHKERRQ(ierr);
+
+	// store computed temperature, enforce boundary constraints
+	ierr = JacResUpdateTemp(jr); CHKERRQ(ierr);
+
+	// copy temperature to markers
+	ierr = ADVMarkSetTempVector(actx); CHKERRQ(ierr);
+
+	// project temperature from markers to grid
+	ierr = ADVProjHistMarkToGrid(actx); CHKERRQ(ierr);
+	
+	// initialize temperature
+	ierr = JacResInitTemp(&lm->jr); CHKERRQ(ierr);
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+
+//	ObjFunct objf;   // objective function
+//	ierr = ObjFunctCreate(&objf, &IOparam, &lm->surf, fb); CHKERRQ(ierr);
+//	ierr = ObjFunctDestroy(&objf); CHKERRQ(ierr);
+
+//---------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,274 @@
+#==============================================================================
+#
+#   Project      : LaMEM
+#   License      : MIT, see LICENSE file for details
+#   Contributors : Anton Popov, Boris Kaus, see AUTHORS file for complete list
+#   Organization : Institute of Geosciences, Johannes-Gutenberg University, Mainz
+#   Contact      : kaus@uni-mainz.de, popov@uni-mainz.de
+#
+#==============================================================================
+
+# Include platform-specific constants
+
+include Makefile.in
+
+#====================================================
+
+# Include PETSc library
+#
+# Environmental variables for PETSc installation directories:
+# PETSC_DEB = /directory/where/petsc/debug/is/installed
+# PETSC_OPT = /directory/where/petsc/optimized/is/installed
+# FASTSCAPELIB = /directory/where/FastScapeLib/is/located
+#
+# LaMEM compilation command:
+#  make mode=deb all (compile debug version of LaMEM and put in /bin/deb)
+#  make mode=opt all (compile optimized version of LaMEM and put in /bin/opt)
+#  make all          (compile optimized version of LaMEM and put in /bin/opt)
+#  make mode=optFS all (compile optimized version of LaMEM with fastscape and put in /bin/optFS, and don't use FastScape)
+#  make mode=optFS all surface=SURFACE=2 (compile optimized version of LaMEM with fastscape and put in /bin/optFS, and use FastScape)
+ifeq ($(mode), deb)
+ifeq (${PETSC_DEB},)
+$(error Environmental variable PETSC_DEB must be set to PETSc debug installation directory)
+endif
+PETSC_DIR = ${PETSC_DEB}
+else ifeq ($(mode), opt)
+ifeq (${PETSC_OPT},)
+$(error Environmental variable PETSC_OPT must be set to PETSc optimized installation directory)
+endif
+PETSC_DIR = ${PETSC_OPT}
+else ifeq ($(mode), optFS)
+# ifneq (, $(filter,${FASTSCAPE_LIB} ${PETSC_OPT}))
+ifeq (${FASTSCAPE_LIB},)
+${error Environmental variable PETSC_OPT and FASTSCAPE_LIB must be set to installation directory, respectively}
+else ifeq (${PETSC_OPT},)
+${error Environmental variable PETSC_OPT and FASTSCAPE_LIB must be set to installation directory, respectively}
+endif
+PETSC_DIR = ${PETSC_OPT}
+FASTSCAPE_DIR = ${FASTSCAPE_LIB}
+else
+$(error Unknown compilation mode specified)
+endif
+
+include ${PETSC_DIR}/lib/petsc/conf/variables
+include ${PETSC_DIR}/lib/petsc/conf/rules
+
+# Define PETSc-based C++ compiler command
+CCOMPILER = ${CXX} ${CXX_FLAGS} ${CXXFLAGS} ${CCPPFLAGS}
+
+# Define FastScape-based fortran compiler command
+GF = gfortran
+# Define FastScapeFortranLib 
+FS_LIB = -L${FASTSCAPE_DIR} -lfastscapelib_fortran
+
+#====================================================
+
+# Define list of LaMEM library source files
+# List files to be excluded after filter-out
+CSRC = $(filter-out LaMEM.cpp, $(wildcard *.cpp))
+FS = $(wildcard *.f90)
+
+#====================================================
+ifeq ($(mode), optFS)
+# Generate lists of library object files:
+COBJ := $(addprefix ../lib/${mode}/, $(notdir $(CSRC:.cpp=.o) $(FS:.f90=.o)))
+
+# Generate lists of library dependency files:
+CDEP := $(addprefix ../dep/${mode}/, $(notdir $(CSRC:.cpp=.d) $(FS:.f90=.d)))
+
+else
+COBJ := $(addprefix ../lib/${mode}/, $(notdir $(CSRC:.cpp=.o)))
+CDEP := $(addprefix ../dep/${mode}/, $(notdir $(CSRC:.cpp=.d)))
+endif
+
+# Get library and executable objects:
+LaMEM = ../bin/${mode}/LaMEM
+LaMEM_OBJ = ../lib/${mode}/LaMEM.o
+LaMEM_DEP = ../dep/${mode}/LaMEM.d
+LaMEM_LIB = ../lib/${mode}/liblamem.a
+
+# If we build LaMEM for BinaryBuilder we link to a PETSc build that has a different name
+ifeq ($(LAMEM_BINARYBUILDER), true)
+	PETSC_LIB := $(filter-out -lpetsc, $(PETSC_LIB))
+	PETSC_LIB += -lpetsc_double_real_Int32
+endif
+#====================================================
+
+# Target list
+
+.PHONY: builddir buildlib lamemlib linkexe lamem print clean_all doc 
+
+# Default target (build executable)
+
+.DEFAULT_TARGET: all
+
+all : lamem
+
+#====================================================
+
+# directory make rules
+
+../bin :
+	@if [ ! -d $@ ]; then mkdir $@; fi
+
+../lib :
+	@if [ ! -d $@ ]; then mkdir $@; fi
+
+../dep :
+	@if [ ! -d $@ ]; then mkdir $@; fi
+
+../bin/${mode} :
+	@if [ ! -d $@ ]; then mkdir $@; fi
+
+../lib/${mode} :
+	@if [ ! -d $@ ]; then mkdir $@; fi
+
+../dep/${mode} :
+	@if [ ! -d $@ ]; then mkdir $@; fi
+
+
+# build directories
+
+builddir : ../bin ../lib ../dep ../bin/${mode} ../lib/${mode} ../dep/${mode}
+
+#====================================================
+
+# force full rebuild when Makefiles are modified
+
+../dep/$(mode)/makefile.stat : Makefile Makefile.in
+	@rm -rf ../lib/$(mode)/*
+	@rm -rf ../bin/$(mode)/*
+	@rm -rf ../dep/$(mode)/*
+	@echo 'makefile timestamp status file' > ../dep/$(mode)/makefile.stat
+
+#====================================================
+
+# Build LaMEM library
+
+lamemlib : builddir buildlib
+
+buildlib : ${LaMEM_LIB}
+
+${LaMEM_LIB} : ../dep/$(mode)/makefile.stat ${COBJ}
+	@echo "............................................."
+	@echo ".......... Building LaMEM Library ..........."
+	@echo "............................................."
+	ar cr $@ ${COBJ}
+	ranlib $@
+
+# Create a dynamic library
+dylib: ${COBJ}
+ifeq ($(mode), optFS)
+	$(CCOMPILER) -shared -fPIC -o ../lib/$(mode)/LaMEMLib.dylib ${COBJ}  ${PETSC_LIB} ${FS_LIB}
+else
+	$(CCOMPILER) -shared -fPIC -o ../lib/$(mode)/LaMEMLib.dylib ${COBJ}  ${PETSC_LIB} 
+endif
+#====================================================
+
+# Link LaMEM executable
+
+lamem : lamemlib linkexe
+
+linkexe : ${LaMEM}
+
+${LaMEM} : ${LaMEM_LIB} ${LaMEM_OBJ}
+	@echo "............................................."
+	@echo "......... Linking LaMEM Executable .........."
+	@echo "............................................."
+ifeq ($(mode), optFS)
+	${CXXLINKER} ${LaMEM_OBJ} ${LaMEM_LIB} ${PETSC_LIB} ${CLIB_FLAGS} ${FS_LIB} -o  $@
+else
+	${CXXLINKER} ${LaMEM_OBJ} ${LaMEM_LIB} ${PETSC_LIB} ${CLIB_FLAGS} -o  $@
+endif
+
+#====================================================
+
+# Pattern rules for automatic generation of object & dependency files
+# Insert full path to object files in dependency files with sed command
+# NOTE: IBM XL compiler generates dependency as a by-product of compilation
+ifeq ($(mode), optFS)
+../lib/${mode}/%.o : %.f90
+	${GF} ${FS_LIB}  -c $< -o $@ 
+endif
+
+# define SURFACE 1 in Cpp script when there isn't a value setting in bash
+surface=SURFACE=1
+
+../lib/${mode}/%.o : %.cpp 
+	${CCOMPILER} ${LAMEM_FLAGS} -D$(surface) -c $< -o $@ 
+
+ifeq ($(PLATFORM), ppc64)
+	@mv -f ../lib/${mode}/$*.d ../dep/${mode}/$*.d.tmp
+else
+	@${CCOMPILER} ${DEPEN_FLAGS} ${LAMEM_FLAGS} $< -o ../dep/${mode}/$*.d.tmp
+endif
+	@sed '1s,^,../lib/${mode}/,' < ../dep/${mode}/$*.d.tmp > ../dep/${mode}/$*.d
+	@rm -f ../dep/${mode}/$*.d.tmp
+
+#====================================================
+
+# Include available dependency files
+-include ${CDEP} ${LaMEM_DEP}
+
+#====================================================
+
+print :
+	@echo "............................................."
+	@echo "........ Environmental variables ............"
+	@echo "............................................."
+ifeq ($(PLATFORM), x86_64)
+ifneq ($(shell mpicc --version 2>&1 | grep -c pgcc), 0)
+	@echo "COMPILER    :  PORTLAND GROUP"
+else ifneq ($(shell mpicc --version 2>&1 | grep -c gcc), 0)
+	@echo "COMPILER    :  GNU "
+else ifneq ($(shell mpicc --version 2>&1 | grep -c icc), 0)
+	@echo "COMPILER    :  INTEL "
+else
+	@echo "COMPILER    :  UNKNOWN "
+endif
+endif
+ifeq ($(PLATFORM), ppc64)
+	@echo "COMPILER    :  IBM "
+endif
+	@echo "............................................."
+	@echo "mode        : " ${mode}
+	@echo "............................................."
+	@echo "PETSC_DIR   : " ${PETSC_DIR}
+	@echo "............................................."
+	@echo "DEPEN_FLAGS : " ${DEPEN_FLAGS}
+	@echo "............................................."
+	@echo "LAMEM_FLAGS : " ${LAMEM_FLAGS}
+	@echo "............................................."
+	@echo "LAMEM_LIB   : " ${LAMEM_LIB}
+	@echo "............................................."
+	@echo "CCOMPILER   : " ${CCOMPILER}
+	@echo "............................................."
+	@echo "CLINKER     : " ${CLINKER}
+	@echo "............................................."
+	@echo "PETSC_LIB   : " ${PETSC_LIB}
+	@echo "............................................."
+ifeq ($(mode), optFS)
+	@echo "............................................."
+	@echo "FASTSCAPE_LIB   : " ${FS_LIB}
+	@echo "............................................."
+endif
+	@echo "CLIB_FLAGS  : " ${CLIB_FLAGS}
+	@echo "............................................."
+
+#====================================================
+
+clean_all :
+	@echo "............................................."
+	@echo ".......... Performing full clean ............"
+	@echo "............................................."
+	@rm -rf ../lib/$(mode)/*
+	@rm -rf ../bin/$(mode)/*
+	@rm -rf ../dep/$(mode)/*
+#====================================================
+
+# Create automatic documentation
+
+doc:
+	PDFLATEX=$(PDFLATEX) BIBTEX=$(BIBTEX) ../doc/Manual/./CreateDevelDoc.sh
+
+#====================================================

--- a/fastscape.cpp
+++ b/fastscape.cpp
@@ -1,0 +1,223 @@
+#include <iostream>
+#include <fstream>
+
+#include <stdio.h>
+#include <string.h>
+
+// LaMEM header file
+#include "LaMEM.h"
+#include "surf.h"
+#include "scaling.h"
+#include "JacRes.h"
+#include "tssolve.h"
+#include "advect.h"
+#include "interpolate.h"
+#include "fastscape.h"
+
+PetscErrorCode fastscape(FreeSurf *surf, AdvCtx *actx)
+{
+    // Apply erosion to the internal free surface of the model
+    PetscErrorCode ierr;
+
+    // free surface cases only
+    if(!surf->UseFreeSurf) PetscFunctionReturn(0);
+
+    // load global nx, ny, dt, time, rangeX, rangeY
+    PetscScalar dt, time, rangeX_begin, rangeY_begin, rangeX_end, rangeY_end, rangeZ_begin, rangeZ_end;
+    PetscScalar rangeX, rangeY, bx, by, bz, ex, ey, ez, chLen, level, cf;
+    PetscInt nx_fs, ny_fs, ind, ind2;
+
+    // nx, ny, dt, time
+    JacRes      *jr;
+    FDSTAG      *fs;
+
+    PetscPrintf(PETSC_COMM_WORLD,"\n============= receive Vz, Topography, grid, model_range from LaMEM ==============\n");
+    
+    jr   = surf->jr;
+    fs = jr->fs;
+
+    nx_fs = fs->dsx.tnods;
+    ny_fs = fs->dsy.tnods;
+
+    dt   = jr->ts->dt;
+    time = jr->ts->time;
+    PetscPrintf(PETSC_COMM_WORLD,"\n nx: %d, ny: %d \n", nx_fs, ny_fs);
+    PetscPrintf(PETSC_COMM_WORLD,"\n dt_LaMEM %f, time: %f \n", dt, time);
+    
+    chLen = fs->scal->length;
+    ierr = FDSTAGGetGlobalBox(fs, &bx, &by, &bz, &ex, &ey, &ez); CHKERRQ(ierr);
+
+    rangeX_begin = bx*chLen;
+    rangeY_begin = by*chLen;
+    rangeZ_begin = bz*chLen;   
+    rangeX_end = ex*chLen;
+    rangeY_end = ey*chLen;
+    rangeZ_end = ez*chLen;
+
+    rangeX = (rangeX_end - rangeX_begin)*1e3;
+    rangeY = (rangeY_end - rangeY_begin)*1e3;
+
+    PetscPrintf(PETSC_COMM_WORLD, "x_begin: %f, x_end: %f, y_begin: %f, y_end: %f; \n",
+            rangeX_begin, rangeX_end, rangeY_begin, rangeY_end);
+
+    // Gather topography and velocity
+    PetscInt    i, j, tnodes;
+    PetscScalar *topo_fs=PETSC_NULL;
+    PetscScalar *vz_fs=PETSC_NULL;
+
+    tnodes = nx_fs*ny_fs;
+
+    topo_fs = (PetscScalar *)malloc(tnodes*sizeof(PetscScalar)); 
+    vz_fs = (PetscScalar *)malloc(tnodes*sizeof(PetscScalar)); 
+
+    // topography
+    ierr = VecScatterCreateToZero(surf->gtopo, &surf->ctx, &surf->gtopo_fs); CHKERRQ(ierr); 
+    ierr = VecScatterBegin(surf->ctx, surf->gtopo, surf->gtopo_fs, INSERT_VALUES, SCATTER_FORWARD); CHKERRQ(ierr);
+    ierr = VecScatterEnd(surf->ctx, surf->gtopo, surf->gtopo_fs, INSERT_VALUES, SCATTER_FORWARD); CHKERRQ(ierr);
+
+    //velocity
+    ierr = VecScatterCreateToZero(surf->vz, &surf->ctx, &surf->vz_fs); CHKERRQ(ierr); 
+    ierr = VecScatterBegin(surf->ctx, surf->vz, surf->vz_fs, INSERT_VALUES, SCATTER_FORWARD); CHKERRQ(ierr);
+    ierr = VecScatterEnd(surf->ctx, surf->vz, surf->vz_fs, INSERT_VALUES, SCATTER_FORWARD); CHKERRQ(ierr);
+
+
+    // Computing topography in rank 0
+    if(ISRankZero(PETSC_COMM_WORLD))
+    {
+        ierr = VecGetArray(surf->gtopo_fs,  &topo_fs);  CHKERRQ(ierr);
+        ierr = VecGetArray(surf->vz_fs,  &vz_fs);  CHKERRQ(ierr);
+
+        double vz_pass[tnodes], topo_pass[tnodes];
+
+        for(j = 0; j < ny_fs; j++) 
+        {   
+            for(i = 0; i < nx_fs; i++) 
+            {
+                ind = j*ny_fs+i;
+                vz_pass[ind]=vz_fs[ind]; // (km)
+                topo_pass[ind]=topo_fs[ind]; // (km)
+    //            printf("topo_fs[0][%d][%d]: %f      \n",j,i,topo_fs[j*ny_fs+i]); // (km)
+    //            printf("vz_fs[0][%d][%d]: %f      \n",j,i,vz_fs[j*ny_fs+i]); // (km)
+            } 
+        }        
+/*
+        for(j = 0; j < ny_fs; j++) 
+        {   
+            for(i = 0; i < nx_fs; i++) 
+            {
+                printf("topo_fs[0][%d][%d]: %f      ",j,i,topo_fs[j*ny_fs+i]); // (km)
+                printf("vz_fs[0][%d][%d]: %f      ",j,i,vz_fs[j*ny_fs+i]); // (km)
+            } 
+        }
+ */       
+        
+        // high level that begin erosion // wating for finish
+        level = 1;
+    /* 
+        jj = surf->numErPhs-1
+        level = surf->erLevels[jj];
+    */
+        // Setting sedimental phase // wating for finish
+     //   jj = surf->numErPhs-1;
+        surf->phase = 3;
+
+        double dt_max = 10; // 最大步长,如果LaMEM计算出来时间步长比这个大，就用这个
+        double dt_n=0.0; 
+        int nsteps = dt/dt_max;
+        // remain supplement (about reminder)
+        if(nsteps < 1) {
+            nsteps = 1;
+            dt_max = dt;
+        }
+        else
+        {
+            nsteps = nsteps + 1;
+            dt_n=dt-(nsteps-1)*dt_max;
+        }
+        printf("nsteps:%d;  dt: %f, dt_n: %f\n",nsteps,dt_max,dt_n);
+        
+        printf("\n ============= receive from LaMEM done ====================\n");
+
+        double* topo_pass_f = NULL;
+
+        topo_pass_f = fastscapeFortran(&nx_fs,&ny_fs,&rangeX,&rangeY,&dt_max,&dt_n,&nsteps,vz_pass,topo_pass);
+  /*      
+        for(j = 1; j < ny_fs+1; j++) 
+        {   
+            for(i = 0; i < nx_fs; i++) 
+            {
+                ind = j*ny_fs+i;
+         //       init_elevation[ind] = init_elevation[ind] + topo_fs[ind]*1e3; // km(LaMEM) to m(FastScape)
+                printf("elevation[0][%d][%d]: %f      \n",j,i,topo_pass_f[ind]); // (km)
+            }
+        }
+*/
+        clearArray();
+
+        // Correction
+        for(j = 0; j < ny_fs; j++) 
+        {   
+            for(i = 0; i < nx_fs; i++) 
+            {
+                ind = j*ny_fs+i;
+                ind2 = (j+1)*ny_fs+i;
+
+                topo_fs[ind] = topo_pass_f[ind2]/1e3; // m(FastScape) to km(LaMEM) 
+
+                if(topo_fs[ind] > rangeZ_end) topo_fs[ind] = rangeZ_end;
+                if(topo_fs[ind] < rangeZ_begin) topo_fs[ind] = rangeZ_begin;
+
+         //       printf("topo_new[%d][%d][%d]: %f      ",L,j,i,topo[L][j][i]); // (km)
+         //       printf("init_elevation[%d]:%f      ",ind,init_elevation[ind]);
+            }
+        }
+        topo_pass_f = NULL;
+    }
+
+    // Broadcast      
+    if(ISParallel(PETSC_COMM_WORLD))
+    {
+        ierr = MPI_Bcast(topo_fs, (PetscMPIInt)tnodes, MPIU_SCALAR, (PetscMPIInt)0, PETSC_COMM_WORLD); CHKERRQ(ierr);
+    }
+
+    // Save topography in different ranks
+    PetscInt    L, sx, sy, sz, nx, ny, nz;
+    PetscScalar ***topo;
+
+    FDSTAG      *fs_actx;
+
+    fs_actx = actx->fs;
+
+    sx = fs_actx->dsx.pstart; nx = fs_actx->dsx.ncels;
+    sy = fs_actx->dsy.pstart; ny = fs_actx->dsy.ncels;
+    sz = fs_actx->dsz.pstart; nz = fs_actx->dsz.ncels;
+
+    L    = (PetscInt)fs->dsz.rank;
+//    printf("\n L: %d \n", L);
+    
+    ierr = DMDAVecGetArray(surf->DA_SURF, surf->gtopo,  &topo);  CHKERRQ(ierr);
+
+
+    START_PLANE_LOOP
+    {
+//        printf("topo_old[%d][%d][%d] : %f      ", L, j, i, topo[L][j][i]);
+        topo[L][j][i] = topo_fs[j*ny_fs+i]; // (km)
+//        printf("topo_new[%d][%d][%d] : %f      ", L, j, i, topo[L][j][i]);
+    }
+    END_PLANE_LOOP  
+
+    ierr = VecRestoreArray(surf->gtopo_fs,  &topo_fs);  CHKERRQ(ierr);
+    
+    ierr = VecScatterDestroy(&surf->ctx); CHKERRQ(ierr);
+    ierr = VecDestroy(&surf->gtopo_fs);   CHKERRQ(ierr);
+    ierr = VecDestroy(&surf->vz_fs);   CHKERRQ(ierr);
+
+    PetscPrintf(PETSC_COMM_WORLD,"\n============= FastScape Done =================\n");
+
+    PetscFunctionReturn(0);
+}
+
+
+
+
+

--- a/fastscape.h
+++ b/fastscape.h
@@ -1,0 +1,28 @@
+#ifndef _FASTSCAPELIB_H_
+#define _FASTSCAPELIB_H_
+
+PetscErrorCode fastscape(FreeSurf*, AdvCtx*);
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+    
+    double *fastscapeFortran(int*,int*,double*,double*,double*,double*,int*,double*,double*);
+    void clearArray();
+#ifdef __cplusplus
+}
+#endif
+/*
+#define START_PLANE_LOOP_FS \
+	for(j = 0; j < ny_fs; j++) \
+	{	for(i = 0; i < nx_fs; i++) \
+		{
+
+// finalize plane access loop
+#define END_PLANE_LOOP_FS \
+		} \
+	}
+*/
+#endif
+

--- a/fastscapeFortran.f90
+++ b/fastscapeFortran.f90
@@ -1,0 +1,167 @@
+module FSFortranLib
+use,intrinsic::iso_c_binding
+implicit none
+double precision, dimension(:), allocatable, target :: h
+contains
+  type(c_ptr) function fastscapeFortran(nx,ny,xl,yl,dt_max,dt_n,nstep,vz,topo) bind(c,NAME="fastscapeFortran") 
+    ! all boundaries are at base level
+    ! initial random topography
+    implicit none 
+    integer :: nx, ny, istep, nstep, i, j, ind, ind2
+    double precision :: xl, yl, dt_max, dt_n, kfsed, m, n, kdsed, g
+    double precision, dimension(:), allocatable :: u, chi, kf, kd
+ !   double precision, dimension(:), allocatable, target :: h
+    double precision, bind(c) :: vz(1089), topo(1089)
+  ! double precision, dimension(:), allocatable :: vz, topo
+  ! interface
+  !   type(c_ptr) function dynamic_array2(length,n)bind(c,name='d_array')
+  !   import
+  !   implicit none
+  !   integer(c_int),intent(in),value::length
+  !   integer(c_int),intent(out)::n
+  !   end function
+  ! end interface
+
+    fastscapeFortran = c_null_ptr
+
+    ! initialize FastScape
+    call FastScape_Init ()
+
+    ! set grid size
+  !  WRITE(*,*) "nx: ",nx,",ny: ",ny
+    call FastScape_Set_NX_NY (nx,ny)
+
+    ! allocate memory
+    call FastScape_Setup ()
+
+    ! set model dimensions
+  !  WRITE(*,*) "xl: ",xl,",yl: ",yl
+    call FastScape_Set_XL_YL (xl,yl)
+
+    ! set time step
+  !  WRITE(*,*) "dt_max: ",dt_max ,", nsteps: ",nstep, ", dt_n :", dt_n
+    call FastScape_Set_DT (dt_max)
+
+    ! set random initial topography
+    allocate (h(nx*ny))
+  !  allocate (topo(nx*ny))
+  !  topo = MALLOC(nx*ny)
+
+    call random_number (h)
+    call FastScape_Init_H (h)
+
+
+
+    outer_loop_topo: do j = 1,ny
+      inner_loop_topo: do i = 1,nx
+      ind = j*ny+i
+      ind2 = (j-1)*ny + i
+  !    PRINT *, "topo[",j,"]","[",i,"]",":", topo(ind2)
+      h(ind)= topo(ind2)
+  !    PRINT *, "topo[",j,"]","[",i,"]",":", h(ind) 
+      end do inner_loop_topo
+    end do outer_loop_topo
+
+    ! set erosional parameters
+    allocate (kf(nx*ny),kd(nx*ny))
+    kf = 2.d-6
+    kfsed = -1.d0
+    m = 0.6d0
+    n = 1.5d0
+    kd = 1.d-1
+    kdsed = -1.d0
+    g = 0.d0
+    call FastScape_Set_Erosional_Parameters (kf, kfsed, m, n, kd, kdsed, g, g, -2.d0)
+
+    ! set uplift rate (uniform while keeping boundaries at base level)
+    allocate (u(nx*ny))
+  !  allocate (vz(nx*ny))
+    u = 1.d-3
+  ! 确认一下读取cpp的数组，是要从0开始还是1
+  ! cpp按行储存，fortran按列储存，这个也要核对一下
+    outer_loop_fs: do j = 1,ny
+      inner_loop_fs: do i = 1,nx
+      ind = j*ny+i
+      ind2 = (j-1)*ny + i
+  !    PRINT *, "vz[",j,"]","[",i,"]",":", vz(ind2)
+      u(ind)= vz(ind2)
+  !    PRINT *, "u[",j,"]","[",i,"]",":", u(ind) 
+      end do inner_loop_fs
+    end do outer_loop_fs
+
+    u(1:nx)=0.d0
+    u(nx:nx*ny:nx)=0.d0
+    u(1:nx*ny:nx)=0.d0
+    u(nx*(ny-1)+1:nx*ny)=0.d0
+    call FastScape_Set_U (u)
+    ! U in left and right boundary = 0;  hight in upper and lower boundary = 0.
+
+    ! set boundary conditions
+    call FastScape_Set_BC (1111)
+
+    ! set number of time steps and initialize counter istep
+    call FastScape_Get_Step (istep)
+  ! 看一下istep等于0还是1
+    !allocate memory to extract chi
+    allocate (chi(nx*ny))
+
+    ! loop on time stepping
+    do while (istep<nstep)
+      if(istep==nstep .and. dt_n>0.d0) then
+        call FastScape_Set_DT (dt_n)
+        ! execute step
+        call FastScape_Execute_Step()
+        ! get value of time step counter
+        call FastScape_Get_Step (istep)
+        ! extract solution
+        call FastScape_Copy_Chi (chi)
+        ! create VTK file
+        call FastScape_VTK (chi, 2.d0)
+        ! outputs h values
+        call FastScape_Copy_h (h)
+        print*,'step',istep
+        print*,'h range:',minval(h),sum(h)/(nx*ny),maxval(h)
+      endif
+      ! execute step
+      call FastScape_Execute_Step()
+      ! get value of time step counter
+      call FastScape_Get_Step (istep)
+      ! extract solution
+      call FastScape_Copy_Chi (chi)
+      ! create VTK file
+      call FastScape_VTK (chi, 2.d0)
+      ! outputs h values
+      call FastScape_Copy_h (h)
+      print*,'step',istep
+      print*,'h range:',minval(h),sum(h)/(nx*ny),maxval(h)
+    enddo
+
+    outer_loop_print: do j = 1,ny
+      inner_loop_print: do i = 1,nx
+      ind = j*nx+i
+ !     ind2 = (j-1)*ny + i    
+ !       PRINT *, "topo[",j,"]","[",i,"]",":", h(ind) 
+      end do inner_loop_print
+    end do outer_loop_print
+
+    fastscapeFortran = c_loc(h(1))
+
+    ! output timing
+    call FastScape_Debug()
+
+    ! end FastScape run
+    call FastScape_Destroy ()
+
+    deallocate (u,kf,kd,chi)
+    return
+  end function
+
+  subroutine clear_array()bind(c,name="clearArray")
+    implicit none
+    if(allocated(h))then
+        deallocate(h)
+        write(*,*)"Clear successfully"
+    endif
+  end subroutine
+
+end module FSFortranLib

--- a/surf.h
+++ b/surf.h
@@ -1,0 +1,160 @@
+/*@ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ **
+ **   Project      : LaMEM
+ **   License      : MIT, see LICENSE file for details
+ **   Contributors : Anton Popov, Boris Kaus, see AUTHORS file for complete list
+ **   Organization : Institute of Geosciences, Johannes-Gutenberg University, Mainz
+ **   Contact      : kaus@uni-mainz.de, popov@uni-mainz.de
+ **
+ ** ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ @*/
+//---------------------------------------------------------------------------
+//.............................. FREE SURFACE ...............................
+//---------------------------------------------------------------------------
+#ifndef __surf_h__
+#define __surf_h__
+
+//---------------------------------------------------------------------------
+
+struct FB;
+struct InterpFlags;
+struct FDSTAG;
+struct JacRes;
+
+//---------------------------------------------------------------------------
+
+// free surface grid
+
+struct FreeSurf
+{
+	JacRes *jr;             // global residual context
+	DM      DA_SURF;        // free surface grid
+	Vec     ltopo, gtopo;   // topography vectors                (local and global)
+	Vec     vx, vy, vz;     // velocity vectors                  (local)
+	Vec     vpatch, vmerge; // patch and merged velocity vectors (global)
+
+	Vec vz_fs;
+	Vec gtopo_fs;
+	VecScatter ctx;
+
+	// flags/parameters
+	PetscInt    UseFreeSurf; // free surface activation flag
+	PetscInt    phaseCorr;   // free surface phase correction flag
+	PetscScalar InitLevel;   // initial level
+	PetscInt    AirPhase;    // air phase number
+	PetscScalar MaxAngle;    // maximum angle with horizon (smoothed if larger)
+
+	// erosion/sedimentation parameters
+	PetscInt    ErosionModel;               // [0-none, 1-infinitely fast, 2-prescribed rate...]
+	PetscInt    SedimentModel;              // [0-none, 1-prescribed rate, 2-gaussian margin...]
+	PetscInt    numLayers;                  // number of sediment layers
+	PetscInt    numErPhs;                   // number of erosion phases
+	PetscScalar timeDelims[_max_sed_layers_-1];  // sediment layers time delimiters
+	PetscScalar timeDelimsEr[_max_er_phases_-1]; // sediment layers time delimiters
+	PetscScalar erRates[_max_er_phases_];        // erosion rates
+	PetscScalar erLevels[_max_er_phases_];       // erosion levels
+	PetscScalar sedRates[_max_sed_layers_  ];    // sedimentation rates
+	PetscScalar sedLevels[_max_sed_layers_];     // sedimentation levels
+	PetscScalar sedRates2nd[_max_sed_layers_  ]; // sedimentation rates
+	PetscInt    sedPhases[_max_sed_layers_  ];   // sediment layers phase numbers
+	PetscScalar marginO[2];                 // lateral coordinates of continental margin - origin
+	PetscScalar marginE[2];                 // lateral coordinates of continental margin - 2nd point
+	PetscScalar hUp;                        // up dip thickness of sediment cover
+	PetscScalar hDown;                      // down dip thickness of sediment cover
+	PetscScalar dTrans;                     // half of transition zone
+
+	// run-time parameters
+	PetscScalar avg_topo; // average topography (updated by all functions changing topography)
+	PetscInt    phase;    // current sediment phase
+
+};
+
+//---------------------------------------------------------------------------
+
+PetscErrorCode FreeSurfCreate(FreeSurf *surf, FB *fb);
+
+PetscErrorCode FreeSurfCreateData(FreeSurf *surf);
+
+PetscErrorCode FreeSurfGetAvgTopo(FreeSurf *surf);
+
+PetscErrorCode FreeSurfReadRestart(FreeSurf *surf, FILE *fp);
+
+PetscErrorCode FreeSurfWriteRestart(FreeSurf *surf, FILE *fp);
+
+PetscErrorCode FreeSurfDestroy(FreeSurf *surf);
+
+// advect topography on the free surface mesh
+PetscErrorCode FreeSurfAdvect(FreeSurf *surf);
+
+// get single velocity component on the free surface
+PetscErrorCode FreeSurfGetVelComp(
+	FreeSurf *surf,
+	PetscErrorCode (*interp) (FDSTAG *, Vec, Vec, InterpFlags),
+	Vec vcomp_grid, Vec vcomp_surf);
+
+// advect/interpolate topography of the free surface
+PetscErrorCode FreeSurfAdvectTopo(FreeSurf *surf);
+
+// smooth topography if maximum angle with horizon is exceeded
+PetscErrorCode FreeSurfSmoothMaxAngle(FreeSurf *surf);
+
+// correct phase ratios based on actual position of the free surface
+PetscErrorCode FreeSurfGetAirPhaseRatio(FreeSurf *surf);
+
+// apply erosion to the free surface
+PetscErrorCode FreeSurfAppErosion(FreeSurf *surf);
+
+// apply sedimentation to the free surface
+PetscErrorCode FreeSurfAppSedimentation(FreeSurf *surf);
+
+// Set topography from file
+PetscErrorCode FreeSurfSetTopoFromFile(FreeSurf *surf, FB *fb);
+
+// Set initial perturbation
+PetscErrorCode FreeSurfSetInitialPerturbation(FreeSurf *surf);
+
+//---------------------------------------------------------------------------
+// SERVICE FUNCTIONS
+//---------------------------------------------------------------------------
+
+PetscInt InterpolateTriangle(
+	PetscScalar *x,   // x-coordinates of triangle
+	PetscScalar *y,   // y-coordinates of triangle
+	PetscScalar *f,   // interpolated field
+	PetscInt    *i,   // indices of triangle corners
+	PetscScalar  xp,  // x-coordinate of point
+	PetscScalar  yp,  // y-coordinate of point
+	PetscScalar  tol, // relative tolerance
+	PetscScalar *fp); // field value in the point
+
+PetscScalar IntersectTriangularPrism(
+	PetscScalar *x,     // x-coordinates of prism base
+	PetscScalar *y,     // y-coordinates of prism base
+	PetscScalar *z,     // z-coordinates of prism top surface
+	PetscInt    *i,     // indices of base corners
+	PetscScalar  vcell, // total volume of cell
+	PetscScalar  bot,   // z-coordinate of bottom plane
+	PetscScalar  top,   // z-coordinate of top plane
+	PetscScalar  tol);  // relative tolerance
+
+//---------------------------------------------------------------------------
+// MACROS
+//---------------------------------------------------------------------------
+
+// NOTE! this macro computes double of actual area
+#define GET_AREA_TRIANG(x1, x2, x3, y1, y2, y3) PetscAbsScalar((x1-x3)*(y2-y3)-(x2-x3)*(y1-y3))
+
+// NOTE! this macro computes double of actual volume
+#define GET_VOLUME_PRISM(x1, x2, x3, y1, y2, y3, z1, z2, z3, level) \
+	((z1+z2+z3)/3.0 > level ? ((z1+z2+z3)/3.0-level)*PetscAbsScalar((x1-x3)*(y2-y3)-(x2-x3)*(y1-y3)) : 0)
+
+#define INTERSECT_EDGE(x1, y1, z1, x2, y2, z2, xp, yp, zp, level, dh) \
+	zp = level; \
+	w  = z1; if(z2 < w) w = z2; if(zp < w) zp = w; \
+	w  = z1; if(z2 > w) w = z2; if(zp > w) zp = w; \
+	w  = 0.0; \
+	if(PetscAbsScalar(z2-z1) > dh) w = (zp-z1)/(z2-z1); \
+	xp = x1 + w*(x2-x1); \
+	yp = y1 + w*(y2-y1);
+
+//---------------------------------------------------------------------------
+#endif


### PR DESCRIPTION
This adds surface processes (back) into LaMEM, by coupling it with [FastScape](https://fastscape.org), which is a flexible surface processes code (see [here](https://github.com/boriskaus/FastScape.jl) for a Julia interface). 

Note that 2 version of the FastScape library exist at the moment: a legacy Fortran library and a newer C++ library. As far as we can tell, the C++ version does not yet have the same functionality as the Fortran version, which is why we stick with the older version for the moment.

To use this, you will need to compile a static library of the Fortran version of FastScape in the Fortran version, or link a shared library of FastScape with the path is included in the *.out

new modes of compile: 
```
# make mode=deb all (compile debug version of LaMEM and put in /bin/deb)
# make mode=opt all (compile optimized version of LaMEM and put in /bin/opt)
# make all          (compile optimized version of LaMEM and put in /bin/opt)
# make mode=optFS all (compile optimized version of LaMEM with fastscape and put in /bin/optFS, and don't use FastScape)
# make mode=optFS all surface=SURFACE=1 (compile optimized version of LaMEM with fastscape and put in /bin/optFS, and don't use FastScape)
# make mode=optFS all surface=SURFACE=2 (compile optimized version of LaMEM with fastscape and put in /bin/optFS, and use FastScape)
```