### PR TITLE
LaMEM with FastScapeFortranLib

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,11 +19,14 @@ include Makefile.in
 # Environmental variables for PETSc installation directories:
 # PETSC_DEB = /directory/where/petsc/debug/is/installed
 # PETSC_OPT = /directory/where/petsc/optimized/is/installed
+# FASTSCAPELIB = /directory/where/FastScapeLib/is/located
 #
 # LaMEM compilation command:
 #  make mode=deb all (compile debug version of LaMEM and put in /bin/deb)
 #  make mode=opt all (compile optimized version of LaMEM and put in /bin/opt)
 #  make all          (compile optimized version of LaMEM and put in /bin/opt)
+#  make mode=optFS all surface=SURFACE=2 (compile optimized version of LaMEM with fastscape and put in /bin/optFS)
+#  surf_mode = 1; don't use fastscape; surf_mode = 2; use fastscape
 
 ifeq ($(mode), deb)
 ifeq (${PETSC_DEB},)
@@ -35,6 +38,15 @@ ifeq (${PETSC_OPT},)
 $(error Environmental variable PETSC_OPT must be set to PETSc optimized installation directory)
 endif
 PETSC_DIR = ${PETSC_OPT}
+else ifeq ($(mode), optFS)
+# ifneq (, $(filter,${FASTSCAPE_LIB} ${PETSC_OPT}))
+ifeq (${FASTSCAPE_LIB},)
+${error Environmental variable PETSC_OPT and FASTSCAPE_LIB must be set to installation directory, respectively}
+else ifeq (${PETSC_OPT},)
+${error Environmental variable PETSC_OPT and FASTSCAPE_LIB must be set to installation directory, respectively}
+endif
+PETSC_DIR = ${PETSC_OPT}
+FASTSCAPE_DIR = ${FASTSCAPE_LIB}
 else
 $(error Unknown compilation mode specified)
 endif
@@ -45,19 +57,30 @@ include ${PETSC_DIR}/lib/petsc/conf/rules
 # Define PETSc-based C++ compiler command
 CCOMPILER = ${CXX} ${CXX_FLAGS} ${CXXFLAGS} ${CCPPFLAGS}
 
+# Define FastScape-based fortran compiler command
+GF = gfortran
+# Define FastScapeFortranLib 
+FS_LIB = -L${FASTSCAPE_DIR} -lfastscapelib_fortran
+
 #====================================================
 
 # Define list of LaMEM library source files
 # List files to be excluded after filter-out
 CSRC = $(filter-out LaMEM.cpp, $(wildcard *.cpp))
+FS = $(wildcard *.f90)
 
 #====================================================
-
+ifeq ($(mode), optFS)
 # Generate lists of library object files:
-COBJ := $(addprefix ../lib/${mode}/, $(notdir $(CSRC:.cpp=.o)))
+COBJ := $(addprefix ../lib/${mode}/, $(notdir $(CSRC:.cpp=.o) $(FS:.f90=.o)))
 
 # Generate lists of library dependency files:
+CDEP := $(addprefix ../dep/${mode}/, $(notdir $(CSRC:.cpp=.d) $(FS:.f90=.d)))
+
+else
+COBJ := $(addprefix ../lib/${mode}/, $(notdir $(CSRC:.cpp=.o)))
 CDEP := $(addprefix ../dep/${mode}/, $(notdir $(CSRC:.cpp=.d)))
+endif
 
 # Get library and executable objects:
 LaMEM = ../bin/${mode}/LaMEM
@@ -74,7 +97,7 @@ endif
 
 # Target list
 
-.PHONY: builddir buildlib lamemlib linkexe lamem print clean_all doc
+.PHONY: builddir buildlib lamemlib linkexe lamem print clean_all doc 
 
 # Default target (build executable)
 
@@ -136,8 +159,11 @@ ${LaMEM_LIB} : ../dep/$(mode)/makefile.stat ${COBJ}
 
 # Create a dynamic library
 dylib: ${COBJ}
+ifeq ($(mode), optFS)
+	$(CCOMPILER) -shared -fPIC -o ../lib/$(mode)/LaMEMLib.dylib ${COBJ}  ${PETSC_LIB} ${FS_LIB}
+else
 	$(CCOMPILER) -shared -fPIC -o ../lib/$(mode)/LaMEMLib.dylib ${COBJ}  ${PETSC_LIB} 
-
+endif
 #====================================================
 
 # Link LaMEM executable
@@ -150,16 +176,28 @@ ${LaMEM} : ${LaMEM_LIB} ${LaMEM_OBJ}
 	@echo "............................................."
 	@echo "......... Linking LaMEM Executable .........."
 	@echo "............................................."
-	${CXXLINKER} ${LaMEM_OBJ} ${LaMEM_LIB} ${PETSC_LIB} ${CLIB_FLAGS} -o $@
+ifeq ($(mode), optFS)
+	${CXXLINKER} ${LaMEM_OBJ} ${LaMEM_LIB} ${PETSC_LIB} ${CLIB_FLAGS} ${FS_LIB} -o  $@
+else
+	${CXXLINKER} ${LaMEM_OBJ} ${LaMEM_LIB} ${PETSC_LIB} ${CLIB_FLAGS} -o  $@
+endif
 
 #====================================================
 
 # Pattern rules for automatic generation of object & dependency files
 # Insert full path to object files in dependency files with sed command
 # NOTE: IBM XL compiler generates dependency as a by-product of compilation
+ifeq ($(mode), optFS)
+../lib/${mode}/%.o : %.f90
+	${GF} ${FS_LIB}  -c $< -o $@ 
+endif
 
-../lib/${mode}/%.o : %.cpp
-	${CCOMPILER} ${LAMEM_FLAGS} -c $< -o $@
+# define SURFACE 1 in Cpp script when there isn't a value setting in bash
+surface=SURFACE=1
+
+../lib/${mode}/%.o : %.cpp 
+	${CCOMPILER} ${LAMEM_FLAGS} -D$(surface) -c $< -o $@ 
+
 ifeq ($(PLATFORM), ppc64)
 	@mv -f ../lib/${mode}/$*.d ../dep/${mode}/$*.d.tmp
 else
@@ -210,6 +248,11 @@ endif
 	@echo "............................................."
 	@echo "PETSC_LIB   : " ${PETSC_LIB}
 	@echo "............................................."
+ifeq ($(mode), optFS)
+	@echo "............................................."
+	@echo "FASTSCAPE_LIB   : " ${FS_LIB}
+	@echo "............................................."
+endif
 	@echo "CLIB_FLAGS  : " ${CLIB_FLAGS}
 	@echo "............................................."
 
@@ -222,7 +265,6 @@ clean_all :
 	@rm -rf ../lib/$(mode)/*
 	@rm -rf ../bin/$(mode)/*
 	@rm -rf ../dep/$(mode)/*
-
 #====================================================
 
 # Create automatic documentation

--- a/src/scaling.cpp
+++ b/src/scaling.cpp
@@ -250,6 +250,16 @@ PetscErrorCode ScalingCreate(Scaling *scal, FB *fb, PetscBool PrintOutput)
 		sprintf(scal->lbl_gas_constant,      "[J/mol/K]");
 	}
 
+	if(2 == SURFACE)
+	{
+		time   = 1.0;
+		length = 1.0;
+		yr     = 3600.0*24.0*365.25;	
+		scal->time_fs 			  = time/yr; 				   sprintf(scal->lbl_time_fs,         "[yr]");   
+		scal->length_fs			  = length;					   sprintf(scal->lbl_length_fs,       "[m]");  	
+		scal->velocity_fs   	  = length/time/yr;			   sprintf(scal->lbl_velocity_fs,     "[m/yr]");  
+	}
+
 	PetscFunctionReturn(0);
 }
 //---------------------------------------------------------------------------

--- a/src/scaling.h
+++ b/src/scaling.h
@@ -96,6 +96,11 @@ struct Scaling
 	PetscScalar heat_production;    // power / mass
 	PetscScalar expansivity;        // 1 / temperature
 
+	// units in FastScape
+	PetscScalar time_fs;
+	PetscScalar length_fs;
+	PetscScalar velocity_fs;
+
 	// output labels
 	char lbl_unit             [_lbl_sz_];
 	char lbl_angle            [_lbl_sz_];
@@ -113,6 +118,10 @@ struct Scaling
 	char lbl_dissipation_rate [_lbl_sz_];
 	char lbl_angular_velocity [_lbl_sz_];
 	char lbl_volumetric_force [_lbl_sz_];
+
+	char lbl_time_fs          [_lbl_sz_];
+	char lbl_length_fs        [_lbl_sz_];
+	char lbl_velocity_fs      [_lbl_sz_];
 
 	// material parameters labels
 	char lbl_density          [_lbl_sz_];

--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -36,7 +36,9 @@ PetscErrorCode FreeSurfCreate(FreeSurf *surf, FB *fb)
 	// initialize
 	surf->phaseCorr   =  1;
 	surf->AirPhase    = -1;
-
+	surf->SurfMode	  =  0;
+	surf->refine	  =  1;
+	
 	// check whether free surface is activated
 	ierr = getIntParam(fb, _OPTIONAL_, "surf_use", &surf->UseFreeSurf, 1,  1); CHKERRQ(ierr);
 
@@ -52,41 +54,68 @@ PetscErrorCode FreeSurfCreate(FreeSurf *surf, FB *fb)
 	ierr = getScalarParam(fb, _REQUIRED_, "surf_level",         &surf->InitLevel,     1,  scal->length); CHKERRQ(ierr);
 	ierr = getIntParam   (fb, _REQUIRED_, "surf_air_phase",     &surf->AirPhase,      1,  maxPhaseID);   CHKERRQ(ierr);
 	ierr = getScalarParam(fb, _OPTIONAL_, "surf_max_angle",     &surf->MaxAngle,      1,  scal->angle);  CHKERRQ(ierr);
+
+	ierr = getIntParam   (fb, _OPTIONAL_, "surf_mode",      &surf->SurfMode,  1,  2);            CHKERRQ(ierr);
+
 	ierr = getIntParam   (fb, _OPTIONAL_, "erosion_model",      &surf->ErosionModel,  1,  2);            CHKERRQ(ierr);
 	ierr = getIntParam   (fb, _OPTIONAL_, "sediment_model",     &surf->SedimentModel, 1,  3);            CHKERRQ(ierr);
 
-	if(surf->ErosionModel == 2)
+	if (SURFACE == 1 && surf->SurfMode > 1 )
 	{
-		// sedimentation model parameters
-		ierr = getIntParam   (fb, _REQUIRED_, "er_num_phases",  &surf->numErPhs,  1,                 _max_er_phases_);   CHKERRQ(ierr);
-		ierr = getScalarParam(fb, _REQUIRED_, "er_time_delims",  surf->timeDelimsEr, surf->numErPhs-1, scal->time);        CHKERRQ(ierr);
-		ierr = getScalarParam(fb, _REQUIRED_, "er_rates",        surf->erRates,   surf->numErPhs,   scal->velocity);    CHKERRQ(ierr);
-		ierr = getScalarParam(fb, _REQUIRED_, "er_levels",       surf->erLevels,  surf->numErPhs,   scal->length);    CHKERRQ(ierr);
-	}
-	if(surf->SedimentModel == 1 || surf->SedimentModel == 2 || surf->SedimentModel == 3 )
-	{
-		// sedimentation model parameters
-		ierr = getIntParam   (fb, _REQUIRED_, "sed_num_layers",  &surf->numLayers,  1,                 _max_sed_layers_);  CHKERRQ(ierr);
-		ierr = getScalarParam(fb, _REQUIRED_, "sed_time_delims",  surf->timeDelims, surf->numLayers-1, scal->time);        CHKERRQ(ierr);
-		ierr = getScalarParam(fb, _REQUIRED_, "sed_rates",        surf->sedRates,   surf->numLayers,   scal->velocity);    CHKERRQ(ierr);
-		ierr = getIntParam   (fb, _REQUIRED_, "sed_phases",       surf->sedPhases,  surf->numLayers,   maxPhaseID);        CHKERRQ(ierr);
-		ierr = getScalarParam(fb, _REQUIRED_, "sed_levels",       surf->sedLevels,  surf->numLayers,   scal->length);      CHKERRQ(ierr);
+		SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_USER, " There only two choices without compiling with fastscape [surf_mode = 1 or 0] \n");	
 	}
 
-	if(surf->SedimentModel == 2)
+	if(1 == surf->SurfMode)
 	{
-		// sedimentation model parameters
-		ierr = getScalarParam(fb, _REQUIRED_, "marginO",          surf->marginO,    2,                 scal->length);      CHKERRQ(ierr);
-		ierr = getScalarParam(fb, _REQUIRED_, "marginE",          surf->marginE,    2,                 scal->length);      CHKERRQ(ierr);
-		ierr = getScalarParam(fb, _REQUIRED_, "marginE",          surf->marginE,    2,                 scal->length);      CHKERRQ(ierr);
-		ierr = getScalarParam(fb, _REQUIRED_, "hUp",             &surf->hUp,        1,                 scal->length);      CHKERRQ(ierr);
-		ierr = getScalarParam(fb, _REQUIRED_, "hDown",           &surf->hDown,      1,                 scal->length);      CHKERRQ(ierr);
-		ierr = getScalarParam(fb, _REQUIRED_, "dTrans",          &surf->dTrans,     1,                 scal->length);      CHKERRQ(ierr);
+		if(surf->ErosionModel == 2)
+		{
+			// sedimentation model parameters
+			ierr = getIntParam   (fb, _REQUIRED_, "er_num_phases",  &surf->numErPhs,  1,                 _max_er_phases_);   CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "er_time_delims",  surf->timeDelimsEr, surf->numErPhs-1, scal->time);        CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "er_rates",        surf->erRates,   surf->numErPhs,   scal->velocity);    CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "er_levels",       surf->erLevels,  surf->numErPhs,   scal->length);    CHKERRQ(ierr);
+		}
+		if(surf->SedimentModel == 1 || surf->SedimentModel == 2 || surf->SedimentModel == 3 )
+		{
+			// sedimentation model parameters
+			ierr = getIntParam   (fb, _REQUIRED_, "sed_num_layers",  &surf->numLayers,  1,                 _max_sed_layers_);  CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "sed_time_delims",  surf->timeDelims, surf->numLayers-1, scal->time);        CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "sed_rates",        surf->sedRates,   surf->numLayers,   scal->velocity);    CHKERRQ(ierr);
+			ierr = getIntParam   (fb, _REQUIRED_, "sed_phases",       surf->sedPhases,  surf->numLayers,   maxPhaseID);        CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "sed_levels",       surf->sedLevels,  surf->numLayers,   scal->length);      CHKERRQ(ierr);
+		}
+
+		if(surf->SedimentModel == 2)
+		{
+			// sedimentation model parameters
+			ierr = getScalarParam(fb, _REQUIRED_, "marginO",          surf->marginO,    2,                 scal->length);      CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "marginE",          surf->marginE,    2,                 scal->length);      CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "marginE",          surf->marginE,    2,                 scal->length);      CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "hUp",             &surf->hUp,        1,                 scal->length);      CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "hDown",           &surf->hDown,      1,                 scal->length);      CHKERRQ(ierr);
+			ierr = getScalarParam(fb, _REQUIRED_, "dTrans",          &surf->dTrans,     1,                 scal->length);      CHKERRQ(ierr);
+		}
+
+		if (surf->SedimentModel == 3)
+		{
+			ierr = getScalarParam(fb, _REQUIRED_, "sed_rates2nd",        surf->sedRates2nd,   surf->numLayers,   scal->velocity);  CHKERRQ(ierr);
+		}
 	}
 
-	if (surf->SedimentModel == 3)
+	if(2 == surf->SurfMode)
 	{
-		ierr = getScalarParam(fb, _REQUIRED_, "sed_rates2nd",        surf->sedRates2nd,   surf->numLayers,   scal->velocity);  CHKERRQ(ierr);
+		// kf, kd, kfsed, kdsed, can be set as an array
+		ierr = getScalarParam(fb, _OPTIONAL_, "Max_dt",          &surf->Max_dt,   1,                 1.0);      				CHKERRQ(ierr); // m/yr
+		ierr = getScalarParam(fb, _OPTIONAL_, "SPL_kf",          &surf->kf,   	  1,                 1.0);      				CHKERRQ(ierr); // m/yr
+		ierr = getScalarParam(fb, _OPTIONAL_, "SPL_kfsed",       &surf->kfsed,    1,                 1.0);      				CHKERRQ(ierr); // m/yr
+		ierr = getScalarParam(fb, _OPTIONAL_, "SPL_m",           &surf->m,    	  1,                 1.0);      				CHKERRQ(ierr); // non-dimensional
+		ierr = getScalarParam(fb, _OPTIONAL_, "SPL_n",           &surf->n,        1,                 1.0);     				 	CHKERRQ(ierr); // non-dimensional
+		ierr = getScalarParam(fb, _OPTIONAL_, "hillslope_kd",    &surf->kd,       1,                 1.0);      				CHKERRQ(ierr); // m/yr
+		ierr = getScalarParam(fb, _OPTIONAL_, "hillslope_kdsed", &surf->kdsed,    1,                 1.0);      				CHKERRQ(ierr); // m/yr
+		ierr = getScalarParam(fb, _OPTIONAL_, "hillslope_g",     &surf->g,        1,                 1.0);   				 	CHKERRQ(ierr); // non-dimensional
+		ierr = getScalarParam(fb, _OPTIONAL_, "hillslope_gsed",  &surf->gsed,     1,                 1.0);     				 	CHKERRQ(ierr); // non-dimensional
+		ierr = getScalarParam(fb, _OPTIONAL_, "multiFlow_p",     &surf->p,     	  1,                 1.0);    				 	CHKERRQ(ierr); // non-dimensional
+		ierr = getIntParam   (fb, _OPTIONAL_, "fs_refine",       &surf->refine,   1,                 100);    				 	CHKERRQ(ierr); // non-dimensional
 	}
 
 	// print summary
@@ -95,16 +124,26 @@ PetscErrorCode FreeSurfCreate(FreeSurf *surf, FB *fb)
 	PetscPrintf(PETSC_COMM_WORLD, "   Sticky air phase ID       : %lld \n",  (LLD)surf->AirPhase);
     PetscPrintf(PETSC_COMM_WORLD, "   Initial surface level     : %g %s \n",  surf->InitLevel*scal->length, scal->lbl_length);
 
-	PetscPrintf(PETSC_COMM_WORLD, "   Erosion model             : ");
-	if      (surf->ErosionModel == 0)  PetscPrintf(PETSC_COMM_WORLD, "none\n");
-	else if (surf->ErosionModel == 1)  PetscPrintf(PETSC_COMM_WORLD, "infinitely fast\n");
-	else if (surf->ErosionModel == 2)  PetscPrintf(PETSC_COMM_WORLD, "prescribed rate with given level\n");
-   
-	PetscPrintf(PETSC_COMM_WORLD, "   Sedimentation model       : ");
-	if      (surf->SedimentModel == 0) PetscPrintf(PETSC_COMM_WORLD, "none\n");
-	else if (surf->SedimentModel == 1) PetscPrintf(PETSC_COMM_WORLD, "prescribed rate with given level\n");
-	else if (surf->SedimentModel == 2) PetscPrintf(PETSC_COMM_WORLD, "directed sedimentation (continental margin) with prescribed rate\n");
-	else if (surf->SedimentModel == 3) PetscPrintf(PETSC_COMM_WORLD, "prescribed rate\n");
+	if(1 == surf->SurfMode)
+	{
+		PetscPrintf(PETSC_COMM_WORLD, "   Erosion model             : ");
+		if      (surf->ErosionModel == 0)  PetscPrintf(PETSC_COMM_WORLD, "none\n");
+		else if (surf->ErosionModel == 1)  PetscPrintf(PETSC_COMM_WORLD, "infinitely fast\n");
+		else if (surf->ErosionModel == 2)  PetscPrintf(PETSC_COMM_WORLD, "prescribed rate with given level\n");
+	
+		PetscPrintf(PETSC_COMM_WORLD, "   Sedimentation model       : ");
+		if      (surf->SedimentModel == 0) PetscPrintf(PETSC_COMM_WORLD, "none\n");
+		else if (surf->SedimentModel == 1) PetscPrintf(PETSC_COMM_WORLD, "prescribed rate with given level\n");
+		else if (surf->SedimentModel == 2) PetscPrintf(PETSC_COMM_WORLD, "directed sedimentation (continental margin) with prescribed rate\n");
+		else if (surf->SedimentModel == 3) PetscPrintf(PETSC_COMM_WORLD, "prescribed rate\n");
+
+		PetscPrintf(PETSC_COMM_WORLD, "   Sedimentation model       : ");
+	}
+
+	if(2 == surf->SurfMode)
+	{
+		PetscPrintf(PETSC_COMM_WORLD, "   Using FastScape\n ");
+	}
 
 	if(surf->numLayers) PetscPrintf(PETSC_COMM_WORLD, "   Number of sediment layers : %lld \n",  (LLD)surf->numLayers);
 	if(surf->phaseCorr) PetscPrintf(PETSC_COMM_WORLD, "   Correct marker phases     @ \n");
@@ -153,6 +192,13 @@ PetscErrorCode FreeSurfCreateData(FreeSurf *surf)
 		fs->dsx.nproc, fs->dsy.nproc, fs->dsz.nproc,
 		1, 1, lx, ly, NULL, &surf->DA_SURF); CHKERRQ(ierr);
 
+	ierr = DMDACreate3dSetUp(PETSC_COMM_WORLD,
+		DM_BOUNDARY_NONE, DM_BOUNDARY_NONE, DM_BOUNDARY_NONE,
+		DMDA_STENCIL_BOX,
+		fs->dsx.tnods * surf->refine - 1, fs->dsy.tnods * surf->refine - 1, fs->dsz.nproc,
+		fs->dsx.nproc, fs->dsy.nproc, fs->dsz.nproc,
+		1, 1, NULL, NULL, NULL, &surf->DA_SURF_REFINE); CHKERRQ(ierr);
+
 	ierr = DMCreateLocalVector (surf->DA_SURF, &surf->ltopo);  CHKERRQ(ierr);
 	ierr = DMCreateGlobalVector(surf->DA_SURF, &surf->gtopo);  CHKERRQ(ierr);
 	ierr = DMCreateLocalVector (surf->DA_SURF, &surf->vx);     CHKERRQ(ierr);
@@ -160,6 +206,10 @@ PetscErrorCode FreeSurfCreateData(FreeSurf *surf)
 	ierr = DMCreateLocalVector (surf->DA_SURF, &surf->vz);     CHKERRQ(ierr);
 	ierr = DMCreateGlobalVector(surf->DA_SURF, &surf->vpatch); CHKERRQ(ierr);
 	ierr = DMCreateGlobalVector(surf->DA_SURF, &surf->vmerge); CHKERRQ(ierr);
+
+	ierr = DMCreateGlobalVector(surf->DA_SURF, &surf->vz_collect);  CHKERRQ(ierr);
+	ierr = DMCreateGlobalVector(surf->DA_SURF_REFINE, &surf->gtopo_refine);  CHKERRQ(ierr);	
+//	ierr = DMCreateGlobalVector(surf->DA_SURF_REFINE, &surf->vz_refine);  CHKERRQ(ierr);
 
 	PetscFunctionReturn(0);
 }
@@ -260,10 +310,10 @@ PetscErrorCode FreeSurfAdvect(FreeSurf *surf)
 	ierr = FreeSurfGetVelComp(surf, &InterpYFaceCorner, jr->lvy, surf->vy); CHKERRQ(ierr);
 	ierr = FreeSurfGetVelComp(surf, &InterpZFaceCorner, jr->lvz, surf->vz); CHKERRQ(ierr);
 
-	// advect topography
+	// advect topography // change the topography
 	ierr = FreeSurfAdvectTopo(surf); CHKERRQ(ierr);
 
-	// smooth topography spikes
+	// smooth topography spikes // also change the topography 
 	ierr = FreeSurfSmoothMaxAngle(surf); CHKERRQ(ierr);
 
 	// compute & store average topography
@@ -483,20 +533,41 @@ PetscErrorCode FreeSurfAdvectTopo(FreeSurf *surf)
 		cy[11] = (cy[3] + cy[4] + cy[6] + cy[7])/4.0;
 		cy[12] = (cy[4] + cy[5] + cy[7] + cy[8])/4.0;
 
-		// compute deformed grid z-coordinates
-		cz[0]  = step*vz[L][J1][I1] + topo[L][J1][I1];
-		cz[1]  = step*vz[L][J1][I ] + topo[L][J1][I ];
-		cz[2]  = step*vz[L][J1][I2] + topo[L][J1][I2];
-		cz[3]  = step*vz[L][J ][I1] + topo[L][J ][I1];
-		cz[4]  = step*vz[L][J ][I ] + topo[L][J ][I ];
-		cz[5]  = step*vz[L][J ][I2] + topo[L][J ][I2];
-		cz[6]  = step*vz[L][J2][I1] + topo[L][J2][I1];
-		cz[7]  = step*vz[L][J2][I ] + topo[L][J2][I ];
-		cz[8]  = step*vz[L][J2][I2] + topo[L][J2][I2];
-		cz[9]  = (cz[0] + cz[1] + cz[3] + cz[4])/4.0;
-		cz[10] = (cz[1] + cz[2] + cz[4] + cz[5])/4.0;
-		cz[11] = (cz[3] + cz[4] + cz[6] + cz[7])/4.0;
-		cz[12] = (cz[4] + cz[5] + cz[7] + cz[8])/4.0;
+		if( 1 == surf->SurfMode )
+		// using LaMEM original code to advect the node in z direction
+		{
+			// compute deformed grid z-coordinates
+			cz[0]  = step*vz[L][J1][I1] + topo[L][J1][I1];
+			cz[1]  = step*vz[L][J1][I ] + topo[L][J1][I ];
+			cz[2]  = step*vz[L][J1][I2] + topo[L][J1][I2];
+			cz[3]  = step*vz[L][J ][I1] + topo[L][J ][I1];
+			cz[4]  = step*vz[L][J ][I ] + topo[L][J ][I ];
+			cz[5]  = step*vz[L][J ][I2] + topo[L][J ][I2];
+			cz[6]  = step*vz[L][J2][I1] + topo[L][J2][I1];
+			cz[7]  = step*vz[L][J2][I ] + topo[L][J2][I ];
+			cz[8]  = step*vz[L][J2][I2] + topo[L][J2][I2];
+			cz[9]  = (cz[0] + cz[1] + cz[3] + cz[4])/4.0;
+			cz[10] = (cz[1] + cz[2] + cz[4] + cz[5])/4.0;
+			cz[11] = (cz[3] + cz[4] + cz[6] + cz[7])/4.0;
+			cz[12] = (cz[4] + cz[5] + cz[7] + cz[8])/4.0;
+		}
+		// SurfaceMode = 2; using FastScape to advect the node in Z direction; ref to fastscapeFortran.f90
+		if( 2 == surf->SurfMode ) // change the topography
+		{
+			cz[0]  = topo[L][J1][I1];
+			cz[1]  = topo[L][J1][I ];
+			cz[2]  = topo[L][J1][I2];
+			cz[3]  = topo[L][J ][I1];
+			cz[4]  = topo[L][J ][I ];
+			cz[5]  = topo[L][J ][I2];
+			cz[6]  = topo[L][J2][I1];
+			cz[7]  = topo[L][J2][I ];
+			cz[8]  = topo[L][J2][I2];
+			cz[9]  = (cz[0] + cz[1] + cz[3] + cz[4])/4.0;
+			cz[10] = (cz[1] + cz[2] + cz[4] + cz[5])/4.0;
+			cz[11] = (cz[3] + cz[4] + cz[6] + cz[7])/4.0;
+			cz[12] = (cz[4] + cz[5] + cz[7] + cz[8])/4.0;	
+		}
 
 		// compute updated node position if background strain rate is defined
 		X += step*Exx*(X - Rxx);
@@ -519,7 +590,7 @@ PetscErrorCode FreeSurfAdvectTopo(FreeSurf *surf)
 
 		// store advected topography
 		advect[L][J][I] = Z;
-
+	
 	}
 	END_PLANE_LOOP
 

--- a/src/surf.h
+++ b/src/surf.h
@@ -32,6 +32,15 @@ struct FreeSurf
 	Vec     vx, vy, vz;     // velocity vectors                  (local)
 	Vec     vpatch, vmerge; // patch and merged velocity vectors (global)
 
+	Vec 	vz_fs, vz_collect;
+	Vec 	gtopo_fs;
+	DM		DA_SURF_REFINE;	 // free surface grid after refinement
+	Vec 	gtopo_refine;
+	VecScatter ctx;
+
+//	Vec vz_refine, gtopo_refine;
+
+
 	// flags/parameters
 	PetscInt    UseFreeSurf; // free surface activation flag
 	PetscInt    phaseCorr;   // free surface phase correction flag
@@ -40,6 +49,9 @@ struct FreeSurf
 	PetscScalar MaxAngle;    // maximum angle with horizon (smoothed if larger)
 
 	// erosion/sedimentation parameters
+	
+	PetscInt    SurfMode;               // [0-none, 1-original code, 2-FastScape...]
+	
 	PetscInt    ErosionModel;               // [0-none, 1-infinitely fast, 2-prescribed rate...]
 	PetscInt    SedimentModel;              // [0-none, 1-prescribed rate, 2-gaussian margin...]
 	PetscInt    numLayers;                  // number of sediment layers
@@ -57,6 +69,22 @@ struct FreeSurf
 	PetscScalar hUp;                        // up dip thickness of sediment cover
 	PetscScalar hDown;                      // down dip thickness of sediment cover
 	PetscScalar dTrans;                     // half of transition zone
+
+	PetscScalar kf;		// the bedrock river incision (SPL) rate parameter (or Kf) in meters (to the power 1-2m) per year
+	PetscScalar kfsed;  // sediment river incision (SPL) rate parameter (or Kf) in meters (to the power 1-2m) per year; note that when kfsed < 0, 
+						// its value is not used, i.e., kf for sediment and bedrock have the same value, regardless of sediment thickness
+	PetscScalar m;		// drainage area exponent in the SPL
+	PetscScalar n;		// slope exponent in the SPL
+	PetscScalar kd;		// the bedrock transport coefficient (or diffusivity) for hillslope processes in meter squared per year
+	PetscScalar kdsed;  // sediment transport coefficient (or diffusivity) for hillslope processes in meter squared per year, note that when kdsed < 0, 
+						// its value is not used, i.e., kd for sediment and bedrock have the same value, regardless of sediment thickness
+	PetscScalar g;		// bedrock dimensionless deposition/transport coefficient for the enriched SPL 
+	PetscScalar gsed;   //sediment dimensionless deposition/transport coefficient for the enriched SPL, note that when gsed < 0, 
+						//its value is not used, i.e., g for sediment and bedrock have the same value, regardless of sediment thickness   
+	PetscScalar p;		// slope exponent for multi-direction flow; the distribution of flow among potential receivers 
+						//(defined as the neighbouring nodes that define a negative slope)is proportional to local slope to power p
+	PetscInt    refine;	// whether refine the grid in FastScape
+	PetscScalar Max_dt; // max dt used in FastScape
 
 	// run-time parameters
 	PetscScalar avg_topo; // average topography (updated by all functions changing topography)


### PR DESCRIPTION
    1. correct the bug when gathering vz to process 0; add a global vector to collect the velocity
    2. add surface mode in .dat, and whether use FastScape can be set in .dat now
    3. add a loading part, parameters used in FastScape can be set in .dat now
    4. change the advecting part, depending on whether to use FastScape
    5. add a refined part, using bilinear interpolation