### PR TITLE
[Feature] Ability to set initial accumulated plastic strain

### DIFF
--- a/src/paraViewOutMark.cpp
+++ b/src/paraViewOutMark.cpp
@@ -81,7 +81,7 @@ PetscErrorCode PVMarkWriteVTU(PVMark *pvmark, const char *dirName)
 	PetscInt    i, idx, connect, phase;
 	uint64_t	length;
 	PetscScalar scal_length;
-	float       xp[3];
+	float       xp[3], APS;
 	size_t      offset = 0;
 
 	PetscFunctionBeginUser;
@@ -141,6 +141,9 @@ PetscErrorCode PVMarkWriteVTU(PVMark *pvmark, const char *dirName)
 
 	fprintf( fp, "\t\t\t\t<DataArray type=\"Int32\" Name=\"Phase\" format=\"appended\" offset=\"%lld\"/>\n", (LLD)offset );
 	offset += sizeof(uint64_t) + sizeof(int)*(size_t)actx->nummark;
+	
+	fprintf( fp, "\t\t\t\t<DataArray type=\"Float32\" Name=\"APS\" format=\"appended\" offset=\"%lld\"/>\n", (LLD)offset );
+	offset += sizeof(uint64_t) + sizeof(float)*(size_t)actx->nummark;
 
 	fprintf( fp, "\t\t\t</PointData>\n");
 
@@ -212,6 +215,18 @@ PetscErrorCode PVMarkWriteVTU(PVMark *pvmark, const char *dirName)
 	}
 	// -------------------
 
+	// -------------------
+	// write field: APS
+	// -------------------
+	length = (uint64_t)sizeof(float)*(actx->nummark);
+	fwrite( &length,sizeof(uint64_t),1, fp);
+	for( i = 0; i < actx->nummark; i++)
+	{
+		APS = (float)actx->markers[i].APS;
+		fwrite( &APS, sizeof(float),1, fp );
+	}
+	// -------------------
+
 	// end header
 	fprintf( fp,"\n\t</AppendedData>\n");
 	fprintf( fp, "</VTKFile>\n");
@@ -272,6 +287,7 @@ PetscErrorCode PVMarkWritePVTU(PVMark *pvmark, const char *dirName)
 	// point data
 	fprintf( fp, "\t\t<PPointData>\n");
 	fprintf(fp,"\t\t\t<PDataArray type=\"Int32\" Name=\"Phase\" NumberOfComponents=\"1\" format=\"appended\"/>\n");
+	fprintf(fp,"\t\t\t<PDataArray type=\"Float32\" Name=\"APS\" NumberOfComponents=\"1\" format=\"appended\"/>\n");
 	fprintf( fp, "\t\t</PPointData>\n");
 
 	for(i = 0; i < actx->nproc; i++){

--- a/src/paraViewOutPassiveTracers.h
+++ b/src/paraViewOutPassiveTracers.h
@@ -32,6 +32,7 @@ struct PVPtr
 	PetscInt  Pressure;
 	PetscInt  Phase;
 	PetscInt  MeltFraction;
+	PetscInt  APS;
 	PetscInt  ID;
 	PetscInt  Active;
 	PetscInt  Grid_mf;

--- a/src/passive_tracer.cpp
+++ b/src/passive_tracer.cpp
@@ -180,6 +180,8 @@ PetscErrorCode ADVPtrReCreateStorage(AdvCtx *actx)
 		ierr = VecCreateSeq(PETSC_COMM_SELF,actx->Ptr->nummark ,&actx->Ptr->Melt_Grid);      CHKERRQ(ierr);
 		ierr = VecZeroEntries(actx->Ptr->Melt_Grid); CHKERRQ(ierr);
 
+		ierr = VecCreateSeq(PETSC_COMM_SELF,actx->Ptr->nummark ,&actx->Ptr->APS);      CHKERRQ(ierr);
+		ierr = VecZeroEntries(actx->Ptr->APS); CHKERRQ(ierr);
 
 	PetscFunctionReturn(0);
 }
@@ -315,7 +317,7 @@ PetscErrorCode ADV_Assign_Phase(AdvCtx *actx)
 	vector <spair>    dist;
 	spair d;
 	Marker   *IP;
-	PetscScalar  X[3],Xm[3],*Xp,*Yp,*Zp,*Pr,*T,*phase;
+	PetscScalar  X[3],Xm[3],*Xp,*Yp,*Zp,*Pr,*T,*phase,*APS;
 	PetscInt     I, J, K,ii,numpassive,imark,ID,nx,ny,n,*markind,id_m;
 	PetscScalar ex,bx,ey,by,ez,bz;
 
@@ -346,6 +348,7 @@ PetscErrorCode ADV_Assign_Phase(AdvCtx *actx)
 	ierr = VecGetArray(actx->Ptr->z, &Zp)           ; CHKERRQ(ierr);
 	ierr = VecGetArray(actx->Ptr->p, &Pr)           ; CHKERRQ(ierr);
 	ierr = VecGetArray(actx->Ptr->T, &T)           ; CHKERRQ(ierr);
+	ierr = VecGetArray(actx->Ptr->APS, &APS)           ; CHKERRQ(ierr);
 	ierr = VecGetArray(actx->Ptr->phase, &phase)           ; CHKERRQ(ierr);
 
 	for(imark=0;imark<numpassive;imark++)
@@ -394,6 +397,7 @@ PetscErrorCode ADV_Assign_Phase(AdvCtx *actx)
 			phase[imark]= ((PetscScalar) IP->phase);
 			T[imark]= IP->T;
 			Pr[imark]= IP->p;
+			APS[imark]= IP->APS;
 			}
 			else
 			{
@@ -401,6 +405,7 @@ PetscErrorCode ADV_Assign_Phase(AdvCtx *actx)
 				phase[imark]= -DBL_MAX;
 				T[imark]= -DBL_MAX;
 				Pr[imark]= -DBL_MAX;
+				APS[imark]= -DBL_MAX;
 			}
 
 	}
@@ -410,6 +415,7 @@ PetscErrorCode ADV_Assign_Phase(AdvCtx *actx)
 	ierr = VecRestoreArray(actx->Ptr->z, &Zp)           ; CHKERRQ(ierr);
 	ierr = VecRestoreArray(actx->Ptr->p, &Pr)           ; CHKERRQ(ierr);
 	ierr = VecRestoreArray(actx->Ptr->T, &T)           ; CHKERRQ(ierr);
+	ierr = VecRestoreArray(actx->Ptr->APS, &APS)        ; CHKERRQ(ierr);
 	ierr = VecRestoreArray(actx->Ptr->phase, &phase)           ; CHKERRQ(ierr);
 
 	if(ISParallel(PETSC_COMM_WORLD))
@@ -425,6 +431,10 @@ PetscErrorCode ADV_Assign_Phase(AdvCtx *actx)
 		ierr = Sync_Vector(actx->Ptr->phase,actx,actx->Ptr->nummark); CHKERRQ(ierr);
 
 		ierr = VecCopy(actx->Ptr->Recv,actx->Ptr->phase); CHKERRQ(ierr);
+
+		ierr = Sync_Vector(actx->Ptr->APS,actx,actx->Ptr->nummark); CHKERRQ(ierr);
+
+		ierr = VecCopy(actx->Ptr->Recv,actx->Ptr->APS); CHKERRQ(ierr);
 	}
 
 
@@ -459,7 +469,7 @@ PetscErrorCode ADVAdvectPassiveTracer(AdvCtx *actx)
 	PetscScalar     *ccx, *ccy, *ccz;
 	PetscScalar     ***lvx, ***lvy, ***lvz, ***lp, ***lT;
 	PetscScalar     vx, vy, vz, xc, yc, zc, xp, yp, zp, dt, Ttop, endx,endy,endz,begx,begy,begz,npx,npy,npz;
-	PetscScalar     *Xp, *Yp,*Zp,*T,*Pr,*phase,*mf_ptr,*Active,*melt_grid;
+	PetscScalar     *Xp, *Yp,*Zp,*T,*Pr,*phase,*mf_ptr,*Active,*melt_grid,*aps;
 	PetscScalar     pShift;
 	PetscScalar     Xm[3],X[3];
 	PetscLogDouble t;
@@ -537,6 +547,7 @@ PetscErrorCode ADVAdvectPassiveTracer(AdvCtx *actx)
 	ierr = VecGetArray(actx->Ptr->phase, &phase)       ; CHKERRQ(ierr);
 	ierr = VecGetArray(actx->Ptr->Melt_fr, &mf_ptr)    ; CHKERRQ(ierr);
 	ierr = VecGetArray(actx->Ptr->Melt_Grid, &melt_grid); CHKERRQ(ierr);
+	ierr = VecGetArray(actx->Ptr->APS, &aps)           ; CHKERRQ(ierr);
 	ierr = VecGetArray(actx->Ptr->C_advection, &Active); CHKERRQ(ierr);
 
 	// scan all markers
@@ -727,6 +738,7 @@ PetscErrorCode ADVAdvectPassiveTracer(AdvCtx *actx)
 	ierr = VecRestoreArray(actx->Ptr->phase, &phase)           ; CHKERRQ(ierr);
 	ierr = VecRestoreArray(actx->Ptr->Melt_fr, &mf_ptr)           ; CHKERRQ(ierr);
 	ierr = VecRestoreArray(actx->Ptr->Melt_Grid, &melt_grid)           ; CHKERRQ(ierr);
+	ierr = VecRestoreArray(actx->Ptr->APS, &aps)         ; CHKERRQ(ierr);
 	ierr = VecRestoreArray(actx->Ptr->C_advection, &Active)           ; CHKERRQ(ierr);
 
 
@@ -790,6 +802,11 @@ PetscErrorCode ADVAdvectPassiveTracer(AdvCtx *actx)
 		ierr = Sync_Vector(actx->Ptr->phase,actx,actx->Ptr->nummark); CHKERRQ(ierr);
 
 		ierr = VecCopy(actx->Ptr->Recv,actx->Ptr->phase); CHKERRQ(ierr);
+
+		//sync APS
+		ierr = Sync_Vector(actx->Ptr->APS,actx,actx->Ptr->nummark); CHKERRQ(ierr);
+
+		ierr = VecCopy(actx->Ptr->Recv,actx->Ptr->APS); CHKERRQ(ierr);
 
 		// number of active tracer in the whole domain
         PetscInt numActTracers_0;
@@ -1119,6 +1136,8 @@ PetscErrorCode ADVPtrDestroy(AdvCtx *actx)
 
 	VecDestroy(&actx->Ptr->Melt_Grid);
 
+	VecDestroy(&actx->Ptr->APS);
+
 	VecDestroy(&actx->Ptr->C_advection);
 
 	VecDestroy(&actx->Ptr->Recv);
@@ -1148,6 +1167,7 @@ PetscErrorCode Passive_Tracer_WriteRestart(AdvCtx *actx, FILE *fp)
 	ierr = VecWriteRestart(actx->Ptr->phase, fp); CHKERRQ(ierr);
 	ierr = VecWriteRestart(actx->Ptr->Melt_fr, fp); CHKERRQ(ierr);
 	ierr = VecWriteRestart(actx->Ptr->Melt_Grid, fp); CHKERRQ(ierr);
+	ierr = VecWriteRestart(actx->Ptr->APS, fp); CHKERRQ(ierr);
 	ierr = VecWriteRestart(actx->Ptr->C_advection, fp); CHKERRQ(ierr);
 	ierr = VecWriteRestart(actx->Ptr->ID, fp); CHKERRQ(ierr);
 	}
@@ -1175,6 +1195,7 @@ PetscErrorCode ReadPassive_Tracers(AdvCtx *actx, FILE *fp)
 		ierr = VecReadRestart(actx->Ptr->phase, fp); CHKERRQ(ierr);
 		ierr = VecReadRestart(actx->Ptr->Melt_fr, fp); CHKERRQ(ierr);
 		ierr = VecReadRestart(actx->Ptr->Melt_Grid, fp); CHKERRQ(ierr);
+		ierr = VecReadRestart(actx->Ptr->APS, fp); CHKERRQ(ierr);
 		ierr = VecReadRestart(actx->Ptr->C_advection, fp); CHKERRQ(ierr);
 		ierr = VecReadRestart(actx->Ptr->ID, fp); CHKERRQ(ierr);
 	}

--- a/src/passive_tracer.h
+++ b/src/passive_tracer.h
@@ -80,6 +80,7 @@ struct P_Tr
 	Vec    T;     // temperature
 	Vec    Melt_fr; // Melt fraction acquired
 	Vec    Melt_Grid; // melt quantity effectively seen by the grid
+	Vec    APS; // accumulated plastic strain
 	Vec    C_advection; // condition to advect marker /*NB: in the future it could be useful to customize better this vector */
 	Vec    Recv;  // Vector that must be used during synching operation
 };


### PR DESCRIPTION
## Motivation

I want to add the ability to set the initial APS, similar to how we can set the initial temperature and phases on the domain. Although pretty simple, this feature involves coordinated PRs in LaMEM, LaMEM.jl and GeophysicalModelGenerator.jl (see below). The changes are meant to be fully backwards compatible. I am leaving this as a draft as I want to get some feedback on the approach.

## Summary of changes

LaMEM.jl (add link)
- adds APS as a property of Grid and passes it to CartData
- adds ability to plot `plast_strain` as a cross-section (name matches Paraview field)
- adds `out_ptr_APS` option to include APS on passive tracers (defaults to 0)

GeophysicalModelGenerator.jl (add link)
- writes APS from Grid as an additional property in the marker binary file (defaults to 0 if not given)
- increments the file header to enable backwards compatibility

**LaMEM (this PR)**
- sets initial APS, if present, from marker binary file
- interprets the file header (previously ignored) as a version number to maintain backwards compatibility
- outputs APS as a field on markers
- optionally outputs APS as a field on passive tracers (defaults to no APS output)
- confirmed all tests pass locally

## Outstanding questions

There is some averaging of initial APS that seems to be related to projecting from grid, to markers, back to grid, e.g., setting random values between 0 and 1 gives a result where the values are between ~0.4 and 0.6. I think it has something to do with APS being a deviatoric variable. Is there a way to work around this? Does it even matter given that the markers retain values between 0 and 1 (see below)?

Should I write a test for this, and which repository would be best for that?

Is this something that can eventually be merged into all 3 repositories?

## Example & screenshots

Using the code

```julia
using Random
Random.seed!(2222)
model.Grid.APS .= 0.0
is_crust = model.Grid.Grid.Z .< 0 .&& model.Grid.Grid.Z .> -50.0
model.Grid.APS[is_crust] = rand(Float64, size(model.Grid.APS[is_crust]))
```

Cross section of initial conditions with initial APS is set to 0-1 in the crust:
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/1b260a7e-1ef9-4229-8a2b-875288ca0671" />

Model3D.vts where APS is still between 0 and 1. **Note: this mesh is not uniform, so the smearing at the edges is correct**:

<img width="1492" height="866" alt="plast_strain_vts" src="https://github.com/user-attachments/assets/1b78fad7-b721-46c7-8c12-ce7b8fe6c35e" />

output.pvd at `t=0` where APS is now ~0.4 to 0.6:
<img width="1492" height="866" alt="plast_strain_pvd" src="https://github.com/user-attachments/assets/8060078e-7b28-4112-bff9-3670f9b2775e" />

Markers after 1 time step with APS output (values between 0 and 1):
<img width="1492" height="866" alt="plast_strain_mark" src="https://github.com/user-attachments/assets/5296011a-b347-4641-8d5c-d7ea3e14f761" />

Passive tracers with APS output:
<img width="1492" height="866" alt="plast_strain_ptr" src="https://github.com/user-attachments/assets/58c73a8e-95c0-457b-ac56-f285e7c1d3d6" />

