### PR TITLE
Update t_33 to generate markers with and without APS

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1054,41 +1054,46 @@ end
                             keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec)
 end
 
-#=
 @testset "t33_Initial_APS" begin
     cd(test_dir)
     dir = "t33_Initial_APS";
 
+    include(joinpath(dir,"t33_analytics.jl"))
+
     keywords = ("|Div|_inf","|Div|_2","|mRes|_2")
     acc      = ((rtol=1e-7,atol=1e-11), (rtol=1e-5, atol=1e-11), (rtol=2e-4,atol=1e-10));
     
+    name0 = "no_APS"
+    name1 = "APS"
+    CreateMarkers_t33(dir, "t33_setup.dat", "./markers_$name0"; NumberCores=1)
+    CreateMarkers_t33(dir, "t33_setup.dat", "./markers_$name1"; APS=0.5, NumberCores=1)
+
     # Test backwards compatibility
-    #   Read marker file created before APS was added
+    #   Read marker file created without APS column
     #   No passive tracer output
-    @test perform_lamem_test(dir,"t33_setup.dat","t33_no_APS.expected", args="-mark_load_file ./mdb -out_dir ./no_APS",
-                            keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec)
-    #   APS output on passive tracers works even if no initial APS is set
-    @test perform_lamem_test(dir,"t33_setup.dat","t33_no_APS.expected", args="-mark_load_file ./mdb -out_ptr 1 -out_ptr_APS 1 -out_dir ./no_APS",
-                            keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec)
+    @test perform_lamem_test(dir,"t33_setup.dat","t33_$name0.expected", args="-mark_load_file ./markers_$name0/mdb",
+                            keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec, clean_dir=false)
+    #   APS output on passive tracers works even if no initial APS is set on markers
+    @test perform_lamem_test(dir,"t33_setup.dat","t33_$name0.expected", args="-mark_load_file ./markers_$name0/mdb -out_ptr 1 -out_ptr_APS 1",
+                            keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec, clean_dir=false)
 
     # Test initial accumulated plastic strain
-    #   Read marker file created by GMG after APS capability was added, APS=0.5 everywhere
+    #   Read marker file created with APS=0.5
     #   No passive tracer output
-    @test perform_lamem_test(dir,"t33_setup.dat","t33_APS_0p5.expected", args="-mark_load_file ./mdb_APS_0p5 -out_dir ./APS_0p5",
-                            keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec)
+    @test perform_lamem_test(dir,"t33_setup.dat","t33_$name1.expected", args="-mark_load_file ./markers_$name1/mdb",
+                            keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec, clean_dir=false)
     #   APS output on passive tracers
-    @test perform_lamem_test(dir,"t33_setup.dat","t33_APS_0p5.expected", args="-mark_load_file ./mdb_APS_0p5 -out_ptr 1 -out_ptr_APS 1 -out_dir ./APS_0p5",
-    keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec)
+    @test perform_lamem_test(dir,"t33_setup.dat","t33_$name1.expected", args="-mark_load_file ./markers_$name1/mdb -out_ptr 1 -out_ptr_APS 1",
+                            keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec, clean_dir=false)
 
     # Test that plast_strain values are correct in both cases
     #   Includes pvd, marker, and passive tracer output
-    include(joinpath(dir,"t33_analytics.jl"))
-    mean_APS0, mean_APS1 = compare_APS(dir, "t33_setup.dat")
+    mean_APS0, mean_APS1 = compare_APS(dir, "t33_setup.dat", "./markers_$name0", "./markers_$name1")
     #  Verify APS values after 2 timesteps
     @test mean_APS0 == 0.0
     @test mean_APS1 == 0.5
+    clean_test_directory(dir)
 end
-=#
 
 end
 

--- a/test/t33_Initial_APS/t33_APS.expected
+++ b/test/t33_Initial_APS/t33_APS.expected
@@ -5,7 +5,7 @@
 -------------------------------------------------------------------------- 
         STAGGERED-GRID FINITE DIFFERENCE CANONICAL IMPLEMENTATION           
 -------------------------------------------------------------------------- 
-Parsing input file : t33.dat 
+Parsing input file : t33_setup.dat 
 Finished parsing input file 
 --------------------------------------------------------------------------
 Time stepping parameters:
@@ -60,6 +60,7 @@ Solution parameters & controls:
    Max. melt fraction (viscosity, density) : 1.    
    Rheology iteration number               : 25  
    Rheology iteration tolerance            : 1e-06    
+   Passive Tracers are active              @ 
    Ground water level type                 : none 
 --------------------------------------------------------------------------
 Advection parameters:
@@ -71,7 +72,16 @@ Advection parameters:
    Markers per cell [nx, ny, nz] : [3, 3, 3] 
    Marker distribution type      : random noise
 --------------------------------------------------------------------------
-Loading markers in parallel from file(s) <./mdb_APS> ... done (0.00752266 sec)
+Loading markers in parallel from file(s) <./markers_APS/mdb> ... done (0.00826161 sec)
+--------------------------------------------------------------------------
+--------------------------------------------------------------------------
+Passive Tracers: 
+   Initial coordinate Box x = [Left,Right] : -1.000000, 1.000000 
+   Initial coordinate Box y = [Front,Back] : -1.000000, 1.000000 
+   Initial coordinate Box z = [Bot, Top]   : -1.000000, 1.000000 
+   # of tracers in [x,y,z] direction       : [10, 10, 10] 
+   Total # of tracers                      : 1000 
+   Tracer advection activation type        : Always active
 --------------------------------------------------------------------------
 Output parameters:
    Output file name                        : output 
@@ -85,9 +95,13 @@ Output parameters:
    Temperature                             @ 
    Deviatoric stress second invariant      @ 
    Deviatoric strain rate second invariant @ 
+   Accumulated Plastic Strain (APS)        @ 
 --------------------------------------------------------------------------
 Marker output parameters:
    Write .pvd file : yes 
+--------------------------------------------------------------------------
+Passive Tracers output parameters:
+   Write Passive tracers pvd file  
 --------------------------------------------------------------------------
 Preconditioner parameters: 
    Matrix type                   : monolithic
@@ -101,88 +115,96 @@ Solver parameters specified:
 --------------------------------------------------------------------------
 ============================== INITIAL GUESS =============================
 --------------------------------------------------------------------------
-  0 SNES Function norm 3.429054972744e+01
+  0 SNES Function norm 3.000000000000e+01
   0 PICARD ||F||/||F0||=1.000000e+00 
     Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  1 SNES Function norm 1.204296519874e-09
+  1 SNES Function norm 3.447357117050e-13
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 1
-SNES solution time      : 0.0438342 (sec)
+SNES solution time      : 0.0442286 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.808956955924e-10 
-      |Div|_2   = 1.200942050950e-09 
+      |Div|_inf = 4.268263780470e-19 
+      |Div|_2   = 2.976369593026e-18 
    Momentum: 
-      |mRes|_2  = 8.982370533532e-11 
+      |mRes|_2  = 3.447357116922e-13 
 --------------------------------------------------------------------------
-Saving output ... done (0.0224544 sec)
+Saving output ... done (0.0291225 sec)
 --------------------------------------------------------------------------
 ================================= STEP 1 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00000000 [ ] 
 Tentative time step : 0.04000000 [ ] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.294916043380e+02
+  0 SNES Function norm 3.447357117050e-13
   0 PICARD ||F||/||F0||=1.000000e+00 
     Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  1 SNES Function norm 9.866084366261e-07
+  1 SNES Function norm 1.702827803925e-14
 --------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 1
-SNES solution time      : 0.0321663 (sec)
+SNES solution time      : 0.0325925 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.008510935694e-10 
-      |Div|_2   = 8.402338717480e-10 
+      |Div|_inf = 1.000905792098e-30 
+      |Div|_2   = 6.292622793103e-30 
    Momentum: 
-      |mRes|_2  = 9.866080788383e-07 
+      |mRes|_2  = 1.702827803925e-14 
 --------------------------------------------------------------------------
 Actual time step : 0.04400 [ ] 
 --------------------------------------------------------------------------
-Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.1158e-04 s
+Advection Passive tracers ... 
+ Currently active tracers    :  1000 
+done (0.000209763 sec)
 --------------------------------------------------------------------------
-Saving output ... done (0.0204886 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.1014e-04 s
+--------------------------------------------------------------------------
+Saving output ... done (0.0280006 sec)
 --------------------------------------------------------------------------
 ================================= STEP 2 =================================
 --------------------------------------------------------------------------
 Current time        : 0.04400000 [ ] 
 Tentative time step : 0.04400000 [ ] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 2.531163135253e+00
+  0 SNES Function norm 1.702827803925e-14
   0 PICARD ||F||/||F0||=1.000000e+00 
     Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  1 SNES Function norm 1.388741476344e-08
+  1 SNES Function norm 2.066419328549e-14
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 1
-SNES solution time      : 0.03207 (sec)
+SNES solution time      : 0.0335445 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 8.821187703900e-12 
-      |Div|_2   = 4.078502999897e-11 
+      |Div|_inf = 2.927413515469e-32 
+      |Div|_2   = 1.879127781752e-31 
    Momentum: 
-      |mRes|_2  = 1.388735487388e-08 
+      |mRes|_2  = 2.066419328549e-14 
 --------------------------------------------------------------------------
 Actual time step : 0.04840 [ ] 
 --------------------------------------------------------------------------
-Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.0588e-04 s
+Advection Passive tracers ... 
+ Currently active tracers    :  1000 
+done (0.000190579 sec)
 --------------------------------------------------------------------------
-Saving output ... done (0.0227087 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.6785e-04 s
+--------------------------------------------------------------------------
+Saving output ... done (0.0238208 sec)
 --------------------------------------------------------------------------
 =========================== SOLUTION IS DONE! ============================
 --------------------------------------------------------------------------
-Total solution time : 0.228827 (sec) 
+Total solution time : 0.249846 (sec) 
 --------------------------------------------------------------------------
 WARNING! There are options you set that were not used!
 WARNING! could be spelling mistake, etc!
-There are 4 unused database options. They are:
+There are 5 unused database options. They are:
 Option left: name:-mat_product_algorithm value: scalable source: code
 Option left: name:-matmatmatmult_via value: scalable source: code
 Option left: name:-matmatmult_via value: scalable source: code
-Option left: name:-ParamFile value: t33.dat source: code
+Option left: name:-ParamFile value: t33_setup.dat source: code

--- a/test/t33_Initial_APS/t33_analytics.jl
+++ b/test/t33_Initial_APS/t33_analytics.jl
@@ -1,16 +1,17 @@
 using Statistics
+using GeophysicalModelGenerator.Printf
 
-function compare_APS(dir, param_file)
+function compare_APS(dir, param_file, dir_markers_APS0, dir_markers_APS1)
     cur_dir = pwd();
     cd(dir)
     outfile0 = "test_markers_no_APS"
-    outfile1 = "test_markers_APS_0p5"
+    outfile1 = "test_markers_APS"
 
     # Tests must be run on 1 core as markers were created with 1 core
-    out0 = run_lamem_local_test(param_file, 1, "-mark_load_file ./mdb -out_pvd 1 -out_file_name $outfile0 -out_ptr 1 -out_ptr_APS 1", opt=true)
+    out0 = run_lamem_local_test(param_file, 1, "-mark_load_file $dir_markers_APS0/mdb -out_pvd 1 -out_file_name $outfile0 -out_ptr 1 -out_ptr_APS 1", opt=true)
     data0, t0 = read_LaMEM_timestep(outfile0, 2, pwd(), fields=("plast_strain [ ]",), surf=false, last=true) 
     
-    out1 = run_lamem_local_test(param_file, 1, "-mark_load_file ./mdb_APS_0p5 -out_pvd 1 -out_file_name $outfile1 -out_ptr 1 -out_ptr_APS 1", opt=true) 
+    out1 = run_lamem_local_test(param_file, 1, "-mark_load_file $dir_markers_APS1/mdb -out_pvd 1 -out_file_name $outfile1 -out_ptr 1 -out_ptr_APS 1", opt=true) 
     data1, t1 = read_LaMEM_timestep(outfile1, 2, pwd(), fields=("plast_strain [ ]",), surf=false, last=true) 
     
     # get the mean value of plast_strain from each model
@@ -18,4 +19,214 @@ function compare_APS(dir, param_file)
     APS1 = data1.fields.plast_strain
     cd(cur_dir)
     return mean(APS0), mean(APS1)
+end
+
+
+# Modified from LaMEM.jl to allow writing markers with or without APS
+function CreateMarkers_t33(dir="./", ParamFile="t33_setup.dat", dir_markers="./markers"; APS=nothing, NumberCores=1, is64bit=false)
+    cur_dir = pwd()
+    cd(dir)
+
+    # Load LaMEM particles grid
+    Grid =   read_LaMEM_inputfile(ParamFile)
+
+    Phases =   zeros(Int64, size(Grid.X));      # Rock numbers
+    Temp =   ones(Float64,size(Grid.X))*200;     # Temperature in C
+    data = (Phases=Phases,Temp=Temp)
+    
+    if APS !== nothing
+        APS = ones(Float64,size(Grid.X))*APS;     # Accumulated Plastic Strain
+        data = (Phases=Phases,Temp=Temp,APS=APS)
+    end
+    
+    # Save julia setup 
+    Model3D = CartData(Grid, data)   # Create LaMEM model:
+
+    # Save LaMEM markers
+    if NumberCores==1
+        # 1 core
+        save_LaMEM_markers_parallel_t33(Model3D, directory=dir_markers, verbose=false) # Create LaMEM marker input on 1 core
+    else
+        #> 1 cores; create partitioning file first
+        PartFile = CreatePartitioningFile(ParamFile,NumberCores, LaMEM_dir="../../bin/opt/");
+        save_LaMEM_markers_parallel_t33(Model3D, PartitioningFile=PartFile,  directory=dir_markers, verbose=false, is64bit=is64bit)     
+    end
+
+    cd(cur_dir)
+
+    return nothing
+end
+
+# Modified from GeophysicalModelGenerator to allow setting the header of the binary file
+function save_LaMEM_markers_parallel_t33(Grid::CartData; PartitioningFile = empty, directory = "./markers", verbose = true, is64bit = false)
+
+    x = ustrip.(Grid.x.val[:, 1, 1])
+    y = ustrip.(Grid.y.val[1, :, 1])
+    z = ustrip.(Grid.z.val[1, 1, :])
+
+    if haskey(Grid.fields, :Phases)
+        Phases = Grid.fields[:Phases]
+    else
+        error("You must provide the field :Phases in the structure")
+    end
+
+    if haskey(Grid.fields, :Temp)
+        Temp = Grid.fields[:Temp]
+    else
+        if verbose
+            println("Field :Temp is not provided; setting it to zero")
+        end
+        Temp = zeros(size(Phases))
+    end
+
+    if haskey(Grid.fields, :APS)
+        APS = Grid.fields[:APS]
+    else
+        APS = nothing
+    end
+
+    if PartitioningFile == empty
+        # in case we run this on 1 processor only
+        Nprocx = 1
+        Nprocy = 1
+        Nprocz = 1
+        xc, yc, zc = x, y, z
+    else
+        Nprocx, Nprocy, Nprocz,
+            xc, yc, zc,
+            nNodeX, nNodeY, nNodeZ = get_processor_partitioning(PartitioningFile, is64bit = is64bit)
+        if verbose
+            @show  Nprocx, Nprocy, Nprocz, xc, yc, zc, nNodeX, nNodeY, nNodeZ
+        end
+    end
+
+    Nproc = Nprocx * Nprocy * Nprocz
+    num, num_i, num_j, num_k = get_numscheme(Nprocx, Nprocy, Nprocz)
+
+    xi, ix_start, ix_end = get_ind(x, xc, Nprocx)
+    yi, iy_start, iy_end = get_ind(y, yc, Nprocy)
+    zi, iz_start, iz_end = get_ind(z, zc, Nprocz)
+
+    x_start = ix_start[num_i[:]]
+    y_start = iy_start[num_j[:]]
+    z_start = iz_start[num_k[:]]
+    x_end = ix_end[num_i[:]]
+    y_end = iy_end[num_j[:]]
+    z_end = iz_end[num_k[:]]
+
+    # Loop over all processors partition
+    for n in 1:Nproc
+        # Extract coordinates for current processor
+
+        part_x = ustrip.(Grid.x.val[x_start[n]:x_end[n], y_start[n]:y_end[n], z_start[n]:z_end[n]])
+        part_y = ustrip.(Grid.y.val[x_start[n]:x_end[n], y_start[n]:y_end[n], z_start[n]:z_end[n]])
+        part_z = ustrip.(Grid.z.val[x_start[n]:x_end[n], y_start[n]:y_end[n], z_start[n]:z_end[n]])
+        part_phs = Phases[x_start[n]:x_end[n], y_start[n]:y_end[n], z_start[n]:z_end[n]]
+        part_T = Temp[x_start[n]:x_end[n], y_start[n]:y_end[n], z_start[n]:z_end[n]]
+        if(APS !== nothing)
+            part_APS = APS[x_start[n]:x_end[n], y_start[n]:y_end[n], z_start[n]:z_end[n]]
+        else
+            part_APS = nothing
+        end
+        num_particles = size(part_x, 1) * size(part_x, 2) * size(part_x, 3)
+
+        # Information vector per processor
+        num_prop = APS===nothing ? 5 : 6       # number of properties we save [x/y/z/phase/T]
+        lvec_info = num_particles
+
+        lvec_prtcls = zeros(Float64, num_prop * num_particles)
+
+        lvec_prtcls[1:num_prop:end] = part_x[:]
+        lvec_prtcls[2:num_prop:end] = part_y[:]
+        lvec_prtcls[3:num_prop:end] = part_z[:]
+        lvec_prtcls[4:num_prop:end] = part_phs[:]
+        lvec_prtcls[5:num_prop:end] = part_T[:]
+        if(part_APS !== nothing)
+            lvec_prtcls[6:num_prop:end] = part_APS[:]
+        end
+
+
+        # Write output files
+        if ~isdir(directory)
+            mkdir(directory)
+        end         # Create dir if not existent
+        fname = @sprintf "%s/mdb.%1.8d.dat"  directory (n - 1)    # Name
+        if verbose
+            println("Writing LaMEM marker file -> $fname")                   # print info
+        end
+        lvec_output = [lvec_info; lvec_prtcls]           # one vec with info about length
+
+        if APS===nothing
+            header = 1211214
+        else
+            header = 1211215
+        end
+        PetscBinaryWrite_Vec_t33(fname, lvec_output, header)            # Write PETSc vector as binary file
+
+    end
+    return
+end
+
+function PetscBinaryWrite_Vec_t33(filename, A, header)
+
+    # Note: use "hton" to transfer to Big Endian type, which is what PETScBinaryRead expects
+    return open(filename, "w+") do f
+        n = length(A)
+        nummark = A[1]            # number of markers
+
+        write(f, hton(Float64(header)))     # header (not actually used)
+        write(f, hton(Float64(nummark)))     # info about # of markers written
+
+        for i in 2:n
+            write(f, hton(Float64(A[i])))   # Write data itself
+        end
+
+    end
+end
+
+# Copied from LaMEM.jl
+function get_numscheme(Nprocx, Nprocy, Nprocz)
+    n = zeros(Int64, Nprocx * Nprocy * Nprocz)
+    nix = zeros(Int64, Nprocx * Nprocy * Nprocz)
+    njy = zeros(Int64, Nprocx * Nprocy * Nprocz)
+    nkz = zeros(Int64, Nprocx * Nprocy * Nprocz)
+
+    num = 0
+    for k in 1:Nprocz
+        for j in 1:Nprocy
+            for i in 1:Nprocx
+                num = num + 1
+                n[num] = num
+                nix[num] = i
+                njy[num] = j
+                nkz[num] = k
+            end
+        end
+    end
+
+    return n, nix, njy, nkz
+end
+
+# Copied from LaMEM.jl
+function get_ind(x, xc, Nprocx)
+    if Nprocx == 1
+        xi = length(x)
+        ix_start = [1]
+        ix_end = [length(x)]
+    else
+
+        xi = zeros(Int64, Nprocx)
+        for k in 1:Nprocx
+            if k == 1
+                xi[k] = length(x[(x .>= xc[k]) .& (x .<= xc[k + 1])])
+            else
+                xi[k] = length(x[(x .> xc[k]) .& (x .<= xc[k + 1])])
+            end
+        end
+        ix_start = cumsum([0; xi[1:(end - 1)]]) .+ 1
+        ix_end = cumsum(xi[1:end])
+    end
+
+
+    return xi, ix_start, ix_end
 end

--- a/test/t33_Initial_APS/t33_no_APS.expected
+++ b/test/t33_Initial_APS/t33_no_APS.expected
@@ -5,7 +5,7 @@
 -------------------------------------------------------------------------- 
         STAGGERED-GRID FINITE DIFFERENCE CANONICAL IMPLEMENTATION           
 -------------------------------------------------------------------------- 
-Parsing input file : t33.dat 
+Parsing input file : t33_setup.dat 
 Finished parsing input file 
 --------------------------------------------------------------------------
 Time stepping parameters:
@@ -60,6 +60,7 @@ Solution parameters & controls:
    Max. melt fraction (viscosity, density) : 1.    
    Rheology iteration number               : 25  
    Rheology iteration tolerance            : 1e-06    
+   Passive Tracers are active              @ 
    Ground water level type                 : none 
 --------------------------------------------------------------------------
 Advection parameters:
@@ -71,7 +72,16 @@ Advection parameters:
    Markers per cell [nx, ny, nz] : [3, 3, 3] 
    Marker distribution type      : random noise
 --------------------------------------------------------------------------
-Loading markers in parallel from file(s) <./mdb> ... done (0.00852894 sec)
+Loading markers in parallel from file(s) <./markers_noAPS/mdb> ... done (0.00772854 sec)
+--------------------------------------------------------------------------
+--------------------------------------------------------------------------
+Passive Tracers: 
+   Initial coordinate Box x = [Left,Right] : -1.000000, 1.000000 
+   Initial coordinate Box y = [Front,Back] : -1.000000, 1.000000 
+   Initial coordinate Box z = [Bot, Top]   : -1.000000, 1.000000 
+   # of tracers in [x,y,z] direction       : [10, 10, 10] 
+   Total # of tracers                      : 1000 
+   Tracer advection activation type        : Always active
 --------------------------------------------------------------------------
 Output parameters:
    Output file name                        : output 
@@ -85,9 +95,13 @@ Output parameters:
    Temperature                             @ 
    Deviatoric stress second invariant      @ 
    Deviatoric strain rate second invariant @ 
+   Accumulated Plastic Strain (APS)        @ 
 --------------------------------------------------------------------------
 Marker output parameters:
    Write .pvd file : yes 
+--------------------------------------------------------------------------
+Passive Tracers output parameters:
+   Write Passive tracers pvd file  
 --------------------------------------------------------------------------
 Preconditioner parameters: 
    Matrix type                   : monolithic
@@ -101,88 +115,96 @@ Solver parameters specified:
 --------------------------------------------------------------------------
 ============================== INITIAL GUESS =============================
 --------------------------------------------------------------------------
-  0 SNES Function norm 3.429054972744e+01
+  0 SNES Function norm 3.000000000000e+01
   0 PICARD ||F||/||F0||=1.000000e+00 
     Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  1 SNES Function norm 1.204296519874e-09
+  1 SNES Function norm 3.447357117050e-13
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 1
-SNES solution time      : 0.0463128 (sec)
+SNES solution time      : 0.0463946 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.808956955924e-10 
-      |Div|_2   = 1.200942050950e-09 
+      |Div|_inf = 4.268263780470e-19 
+      |Div|_2   = 2.976369593026e-18 
    Momentum: 
-      |mRes|_2  = 8.982370533532e-11 
+      |mRes|_2  = 3.447357116922e-13 
 --------------------------------------------------------------------------
-Saving output ... done (0.0260617 sec)
+Saving output ... done (0.02756 sec)
 --------------------------------------------------------------------------
 ================================= STEP 1 =================================
 --------------------------------------------------------------------------
 Current time        : 0.00000000 [ ] 
 Tentative time step : 0.04000000 [ ] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 6.294916043380e+02
+  0 SNES Function norm 3.447357117050e-13
   0 PICARD ||F||/||F0||=1.000000e+00 
     Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  1 SNES Function norm 9.866084366261e-07
+  1 SNES Function norm 1.702827803925e-14
 --------------------------------------------------------------------------
-SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 1
-SNES solution time      : 0.0319112 (sec)
+SNES solution time      : 0.0332672 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 2.008510935694e-10 
-      |Div|_2   = 8.402338717480e-10 
+      |Div|_inf = 1.000905792098e-30 
+      |Div|_2   = 6.292622793103e-30 
    Momentum: 
-      |mRes|_2  = 9.866080788383e-07 
+      |mRes|_2  = 1.702827803925e-14 
 --------------------------------------------------------------------------
 Actual time step : 0.04400 [ ] 
 --------------------------------------------------------------------------
-Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.0539e-04 s
+Advection Passive tracers ... 
+ Currently active tracers    :  1000 
+done (0.000208667 sec)
 --------------------------------------------------------------------------
-Saving output ... done (0.0238554 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.1510e-04 s
+--------------------------------------------------------------------------
+Saving output ... done (0.0282868 sec)
 --------------------------------------------------------------------------
 ================================= STEP 2 =================================
 --------------------------------------------------------------------------
 Current time        : 0.04400000 [ ] 
 Tentative time step : 0.04400000 [ ] 
 --------------------------------------------------------------------------
-  0 SNES Function norm 2.531163135253e+00
+  0 SNES Function norm 1.702827803925e-14
   0 PICARD ||F||/||F0||=1.000000e+00 
     Linear js_ solve converged due to CONVERGED_RTOL iterations 2
-  1 SNES Function norm 1.388741476344e-08
+  1 SNES Function norm 2.066419328549e-14
 --------------------------------------------------------------------------
 SNES Convergence Reason : ||F|| < atol 
 Number of iterations    : 1
-SNES solution time      : 0.032639 (sec)
+SNES solution time      : 0.0334077 (sec)
 --------------------------------------------------------------------------
 Residual summary: 
    Continuity: 
-      |Div|_inf = 8.821187703900e-12 
-      |Div|_2   = 4.078502999897e-11 
+      |Div|_inf = 2.927413515469e-32 
+      |Div|_2   = 1.879127781752e-31 
    Momentum: 
-      |mRes|_2  = 1.388735487388e-08 
+      |mRes|_2  = 2.066419328549e-14 
 --------------------------------------------------------------------------
 Actual time step : 0.04840 [ ] 
 --------------------------------------------------------------------------
-Performing marker control (subgrid algorithm)
-Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.1814e-04 s
+Advection Passive tracers ... 
+ Currently active tracers    :  1000 
+done (0.000240299 sec)
 --------------------------------------------------------------------------
-Saving output ... done (0.028779 sec)
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 0 markers and merged 0 markers in 6.2357e-04 s
+--------------------------------------------------------------------------
+Saving output ... done (0.0253355 sec)
 --------------------------------------------------------------------------
 =========================== SOLUTION IS DONE! ============================
 --------------------------------------------------------------------------
-Total solution time : 0.250712 (sec) 
+Total solution time : 0.253166 (sec) 
 --------------------------------------------------------------------------
 WARNING! There are options you set that were not used!
 WARNING! could be spelling mistake, etc!
-There are 4 unused database options. They are:
+There are 5 unused database options. They are:
 Option left: name:-mat_product_algorithm value: scalable source: code
 Option left: name:-matmatmatmult_via value: scalable source: code
 Option left: name:-matmatmult_via value: scalable source: code
-Option left: name:-ParamFile value: t33.dat source: code
+Option left: name:-ParamFile value: t33_setup.dat source: code

--- a/test/t33_Initial_APS/t33_setup.dat
+++ b/test/t33_Initial_APS/t33_setup.dat
@@ -82,7 +82,6 @@
 #===============================================================================
 
     out_file_name    =  output     # output file name
-    out_dir          =  output_markers     # output directory
     write_VTK_setup  =  true     # write VTK initial model setup
     out_pvd          =  1     # activate writing .pvd file
     out_phase        =  1     # dominant phase


### PR DESCRIPTION
Generating such marker files is not that straightforward, as the necessary changes haven't been merged into LaMEM.jl or GeophysicalModelGeneator yet.

I ended up copying the needed functions from those packages into `t33_analytics.jl` and making small changes to enable writing marker files with and without APS initialized (similar to my PRs in those repos, but maybe not exactly the same). 

Although this works, I'm not sure if it is the best way - happy to consider other approaches!