### PR TITLE
[Docs]: Replace mentions of the old BitBucket repository with the current GitHub one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,21 +15,21 @@ Below, we give specific instructions.
 
 ### 2.1. Fork LaMEM
 
-What forking does is create a copy of LaMEM within your own bitbucket account on which you can do your own work, create branches etc. (or also give other access if you wish). Once you are ready to push a local branch back to LaMEM master, you can create a pull request.
+What forking does is create a copy of LaMEM within your own GitHub account on which you can do your own work, create branches etc. (or also give other access if you wish). Once you are ready to push a local branch back to LaMEM master, you can create a pull request.
 
 In order to fork, please follow the following steps:
 
-1. Login to your BitBucket account and go from there to the LaMEM repository `https://bitbucket.org/bkaus/lamem/src/master/`
-2. Click on the `+` on the left side of the webpage and select `Fork this repository`. It will ask you to give it a Project Name (you could use `LaMEM_Project`, for example). You can make this repo private or public.
+1. Login to your GitHub account and go from there to the LaMEM repository `https://github.com/UniMainzGeo/LaMEM/`
+2. Click on the `Fork` button in the toolbar. You can make this repo private or public.
 3. Next, you clone LaMEM *from your own repository* to your local directory. The easiest way to do this is via the webpage where you go to `Clone` and copy the clone command. Next go to your terminal and type this
    ``` 
-   git clone https://<username>@bitbucket.org/username/lamem.git ./LaMEM
+   git clone https://github.com/<username>/LaMEM.git ./LaMEM
    ```
-   where `username` should be your Bitbucket username (done automatically if you copy it from the wen interface).
+   where `<username>` should be your GitHub username (or copy the command from the web interface).
 4. Change to the directory: `cd ./LaMEM` 
 5. Link the open-source main version of LaMEM (also called upstream version) with your local copy of it by typing on the command-line
    ```
-   git remote add upstream https://bitbucket.org/bkaus/lamem/src/master/
+   git remote add upstream https://github.com/UniMainzGeo/LaMEM.git
    ```
 6. You can now always get the latest changes of the main version of LaMEM into your local copy by typing
    ```
@@ -45,7 +45,7 @@ The workflow is as follows:
    ```
    git checkout master
    ```
-   Alternatively, you can also push a button in te GUI (which is what we tend to do). Many of us use SourceTree which is provided by bitbucket.
+   Alternatively, you can also push a button in the GUI (which is what we tend to do). Many of us use SourceTree which is provided by Atlassian.
 2. Download the main changes of LaMEM into your own copy of the code
    ```
    git pull upstream master
@@ -112,12 +112,12 @@ The LaMEM development team will make sure that things in master work and that te
   
 #### 3.2 Filing a pull request  
 Once you are ready to push back your branch to the main version of LaMEM, you should create a pull request. 
-Creating a pull request is best done through the bitbucket web page:
+Creating a pull request is best done through the GitHub web page:
 
-1. Go to your own bitbucket account and the forked version of LaMEM. 
+1. Go to your own GitHub account and the forked version of LaMEM. 
 2. Select `branches` on the left side and select the branch.
 3. On the right side you will have the option `Create Pull Request`
-4. Click on that, and select as destination on the right `bkaus/lamem` and `master` 
+4. Click on that, and select as destination on the right `UniMainzGeo/LaMEM` and `master` 
 5. Create a title and a description of what the pull request is about
 6. Select Anton and Boris as reviewers
 7. And push `Create Pull Request`

--- a/doc/README
+++ b/doc/README
@@ -5,7 +5,7 @@ The LaMEM documentation is currently rather poor, and much of what was in the
 causing confusion for new users of the code.
 
 If you are a new user, interested to learn the code, we recommend that you look
-at the bitbucket page and at the wiki page that is given there, where we have a
+at the GitHub page and at the wiki page that is given there, where we have a
 number of worked-out examples. You can alsi read the README file in the main
 durectory of LaMEM and follow the instructions there.
 Having a PDF user-guide is also quickly becoming a bit outdated, so whatever we

--- a/docs/src/man/Installation.md
+++ b/docs/src/man/Installation.md
@@ -225,7 +225,7 @@ Configure options: --prefix=/cluster/easybuild/broadwell/software/numlib/PETSc/3
 Once you successfully installed the correct version of PETSc, installing LaMEM should be straightforward.
 You can download the latest version of LaMEM with
 ```
-git clone https://bitbucket.org/bkaus/lamem.git ./LaMEM
+git clone https://github.com/UniMainzGeo/LaMEM.git ./LaMEM
 ```
 Next you need to specify the environmental variables ```PETSC_OPT``` and ```PETSC_DEB```:
 ```

--- a/docs/src/man/LaMEM_Development.md
+++ b/docs/src/man/LaMEM_Development.md
@@ -15,21 +15,21 @@ Below, we give specific instructions.
 
 ### 6.2.1. Fork LaMEM
 
-What forking does is create a copy of LaMEM within your own bitbucket account on which you can do your own work, create branches etc. (or also give other access if you wish). Once you are ready to push a local branch back to LaMEM master, you can create a pull request.
+What forking does is create a copy of LaMEM within your own GitHub account on which you can do your own work, create branches etc. (or also give other access if you wish). Once you are ready to push a local branch back to LaMEM master, you can create a pull request.
 
 In order to fork, please follow the following steps:
 
-1. Login to your BitBucket account and go from there to the LaMEM repository `https://bitbucket.org/bkaus/lamem/src/master/`
-2. Click on the `+` on the left side of the webpage and select `Fork this repository`. It will ask you to give it a Project Name (you could use `LaMEM_Project`, for example). You can make this repo private or public.
+1. Login to your GitHub account and go from there to the LaMEM repository `https://github.com/UniMainzGeo/LaMEM`
+2. Click on the `Fork` button in the toolbar. You can make this repo private or public.
 3. Next, you clone LaMEM *from your own repository* to your local directory. The easiest way to do this is via the webpage where you go to `Clone` and copy the clone command. Next go to your terminal and type this
    ``` 
-   git clone https://<username>@bitbucket.org/username/lamem.git ./LaMEM
+   git clone https://github.com/<username>/LaMEM.git ./LaMEM
    ```
-   where `username` should be your Bitbucket username (done automatically if you copy it from the wen interface).
+   where `<username>` should be your GitHub username (or copy the command from the web interface).
 4. Change to the directory: `cd ./LaMEM` 
 5. Link the open-source main version of LaMEM (also called upstream version) with your local copy of it by typing on the command-line
    ```
-   git remote add upstream https://bitbucket.org/bkaus/lamem/src/master/
+   git remote add upstream https://github.com/UniMainzGeo/LaMEM.git
    ```
 6. You can now always get the latest changes of the main version of LaMEM into your local copy by typing
    ```
@@ -45,7 +45,7 @@ The workflow is as follows:
    ```
    git checkout master
    ```
-   Alternatively, you can also push a button in te GUI (which is what we tend to do). Many of us use SourceTree which is provided by bitbucket.
+   Alternatively, you can also push a button in the GUI (which is what we tend to do). Many of us use SourceTree which is provided by Atlassian.
 2. Download the main changes of LaMEM into your own copy of the code
    ```
    git pull upstream master
@@ -112,12 +112,12 @@ The LaMEM development team will make sure that things in master work and that te
   
 #### 6.3.2 Filing a pull request  
 Once you are ready to push back your branch to the main version of LaMEM, you should create a pull request. 
-Creating a pull request is best done through the bitbucket web page:
+Creating a pull request is best done through the GitHub web page:
 
-1. Go to your own bitbucket account and the forked version of LaMEM. 
+1. Go to your own GitHub account and the forked version of LaMEM. 
 2. Select `branches` on the left side and select the branch.
 3. On the right side you will have the option `Create Pull Request`
-4. Click on that, and select as destination on the right `bkaus/lamem` and `master` 
+4. Click on that, and select as destination on the right `UniMainzGeo/LaMEM` and `master` 
 5. Create a title and a description of what the pull request is about
 6. Select Anton and Boris as reviewers
 7. And push `Create Pull Request`

--- a/docs/src/man/Quickstart.md
+++ b/docs/src/man/Quickstart.md
@@ -102,10 +102,10 @@ We develop LaMEM on Linux and Mac machines, but we also have had success on Wind
 
 ### 2.2.3 Install LaMEM
 
-* Download LaMEM from BitBucket, preferable by using GIT on your system:
+* Download LaMEM from GitHub, preferable by using GIT on your system:
 
 ```
-        $ git clone https://bkaus@bitbucket.org/bkaus/lamem.git ./LaMEM
+        $ git clone https://github.com/UniMainzGeo/LaMEM.git ./LaMEM
 ``` 
 
 * Set the environment variables in your .bashrc or .bash_profile scripts such that the LaMEM makefile knows where to look for PETSc:
@@ -159,9 +159,10 @@ Note that you can look at the ```tests``` directory contains subdirectories that
   You can change the input parameters (such as resolution) by opening the file ```FallingBlock_IterativeSolver.dat``` with a texteditor and changing the parameters.
 
 ### 3.2 Learning more
- As we do not have an extensive user-guide yet (it takes time to create one, but will come at some point..), the best way to learn LaMEM is by looking at the input files in the order that is recommended in the README files. Start with ```/BuildInSetups```, which shows various example with geometries that are specified in the LaMEM input file. 
 
-In addition, you can also look at the [Wiki](https://bitbucket.org/bkaus/lamem/wiki/Home) page (left menu). This will be the location where we will add more extensive documentation on how to use LaMEM.
+You can also look at the [User Guide](https://unimainzgeo.github.io/LaMEM/dev/man/Home/). This website also contains more extensive documentation on how to use LaMEM.
+
+The best way to learn LaMEM is by looking at the input files in the order that is recommended in the README files. Start with ```/BuildInSetups```, which shows various example with geometries that are specified in the LaMEM input file. 
 
 All possible input parameters in LaMEM are listed in the file ```/input_models/input/lamem_input.dat```, which is worthwhile having a look at. Note that not all of these parameters have to be set (we select useful default options in most cases). 
 

--- a/input_models/README
+++ b/input_models/README
@@ -15,9 +15,8 @@ If you are a new user of LaMEM, we suggest you to look at the files
 in the order given below. Where appropriate, we have added README files 
 in the directories with further info.
 
-In addition, you can also look at the Wiki page of the LaMEM BitBucket 
-repository:
-https://bitbucket.org/bkaus/lamem/wiki/Home
+In addition, you can also look at the LaMEM User Guide:
+https://unimainzgeo.github.io/LaMEM/dev/man/Home/
 
 Boris Kaus, Oct. 2020
 


### PR DESCRIPTION
A tech at our university was trying to install LaMEM on our cluster but cloned the repo using the old bitbucket link from in the docs.
To prevent this from happening to others, I replaced any mention of the bitbucket repo with the current GitHub one. 
I also updated a bit of the language that was specific to bitbucket.

Note, this commit only touches docs and md files.