### PR TITLE
Add spatially-limited erosion model (erosion_model = 3)

### DIFF
--- a/src/surf.h
+++ b/src/surf.h
@@ -48,6 +48,8 @@ struct FreeSurf
 	PetscScalar timeDelimsEr[_max_er_phases_-1]; // sediment layers time delimiters
 	PetscScalar erRates[_max_er_phases_];        // erosion rates
 	PetscScalar erLevels[_max_er_phases_];       // erosion levels
+	PetscScalar erXMin[_max_er_phases_];         // erosion x-coordinate minimum
+	PetscScalar erXMax[_max_er_phases_];         // erosion x-coordinate maximum
 	PetscScalar sedRates[_max_sed_layers_  ];    // sedimentation rates
 	PetscScalar sedLevels[_max_sed_layers_];     // sedimentation levels
 	PetscScalar sedRates2nd[_max_sed_layers_  ]; // sedimentation rates


### PR DESCRIPTION
Implements a new erosion model that applies constant erosion rate only within specified x-coordinate ranges. New parameters:
- er_x_min: minimum x-coordinate for erosion zone (per phase)
- er_x_max: maximum x-coordinate for erosion zone (per phase)

Erosion is applied when: x >= er_x_min && x <= er_x_max && z > er_level

Function added using Claude Code with initial prompt:
````
❯ I want you to check the surf.cpp and the test file                        
  /test/t24_Erosion_Sedimentation/Erosion_Sedimentation_2D.dat. I want to   
  add an erosion model: constant erosion rate but only within a given        
  x-coordinates. Tell me what files need to be changed and your plan. 
  Remember specify input parameters at the beginning of the surf.cpp. Make  
  sure that the correct dimensions are specified (velocity or length and    
  such), as internally all is being non-dimensionalized. 
````
