### PR TITLE
Add 3D Bezier push block support with `path_dim` parameter

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "LaMEM",
-  "description": "LaMEM (Lithosphere and Mantle Evolution Model) is a parallel 3D numerical code that can be used to simulate various thermo-mechanical geodynamical processes such as mantle-lithosphere interaction, rifting, subduction, etc.",
+  "description": "LaMEM (Lithosphere and Mantle Evolution Model) is a parallel 3D numerical code that can be used to simulate various thermo-mechanical geodynamical processes such as mantle-lithosphere interaction for rocks that have visco-elasto-plastic rheologies. It was developed to better understand geological processes, particularly related to the dynamics of the crust and lithosphere and their interaction with the mantle. It can also be used to solve geomechanical problems, includes (compressible) poroelasticity, has a gravity solver and an (adjoint) inversion framework. The code uses a marker-in-cell approach with a staggered finite difference discretization and is built on top of PETSc such that it can run on anything from a laptop to a massively parallel machine. A range of (Galerkin) multigrid and iterative solvers are available, for both linear and non-linear rheologies, using Picard and quasi-Newton solvers (provided through the PETSc interface). LaMEM has been tested on a variety of machines ranging from laptops to a massively parallel cluster with 458'752 cores.",
   "creators": [
     {
       "name": "Popov, Anton A.",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "LaMEM",
-  "description": "LaMEM (Lithosphere and Mantle Evolution Model) is a parallel 3D numerical code that can be used to simulate various thermo-mechanical geodynamical processes such as mantle-lithosphere interaction for rocks that have visco-elasto-plastic rheologies. It was developed to better understand geological processes, particularly related to the dynamics of the crust and lithosphere and their interaction with the mantle. It can also be used to solve geomechanical problems, includes (compressible) poroelasticity, has a gravity solver and an (adjoint) inversion framework. The code uses a marker-in-cell approach with a staggered finite difference discretization and is built on top of PETSc such that it can run on anything from a laptop to a massively parallel machine. A range of (Galerkin) multigrid and iterative solvers are available, for both linear and non-linear rheologies, using Picard and quasi-Newton solvers (provided through the PETSc interface). LaMEM has been tested on a variety of machines ranging from laptops to a massively parallel cluster with 458'752 cores.",
+  "description": "LaMEM (Lithosphere and Mantle Evolution Model) is a parallel 3D numerical code that can be used to simulate various thermo-mechanical geodynamical processes such as mantle-lithosphere interaction, rifting, subduction, etc.",
   "creators": [
     {
       "name": "Popov, Anton A.",
@@ -31,5 +31,5 @@
     "id": "MIT"
   },
   "upload_type": "software",
-  "access_right": "open",
+  "access_right": "open"
 }

--- a/input_models/input/lamem_input.dat
+++ b/input_models/input/lamem_input.dat
@@ -180,15 +180,18 @@
     bg_ref_point     = 0.0 0.0 0.0       # background strain rate reference point (fixed)
 
 # Bezier blocks (single entry per block)
+# path_dim = 2 (default): 2D path in x-y plane, path contains (x,y) coordinates
+# path_dim = 3: 3D path, path contains (x,y,z) coordinates
     <BCBlockStart>
-        npath =  2                                 # Number of path points of Bezier curve (path-points only!)
-        theta =  0.0 5.0                           # Orientation angles at path points (counter-clockwise positive)
-        time  =  1.0 2.0                           # Times at path points
-        path  =  0.0 0.0 0.0 10.0                  # Path points x-y coordinates
-        npoly =  4                                 # Number of polygon vertices
-        poly  =  0.0 0.0 0.1 0.0 0.1 0.1 0.0 0.1   # Polygon x-y coordinates at initial time
-        bot   =  0.0                               # Polygon bottom coordinate
-        top   =  0.1                               # Polygon top coordinate
+        npath    =  2                                 # Number of path points of Bezier curve (path-points only!)
+        path_dim =  2                                 # Path dimension: 2 = x-y plane (default), 3 = x-y-z
+        theta    =  0.0 5.0                           # Orientation angles at path points (counter-clockwise positive)
+        time     =  1.0 2.0                           # Times at path points
+        path     =  0.0 0.0 0.0 10.0                  # Path points x-y coordinates (or x-y-z if path_dim=3)
+        npoly    =  4                                 # Number of polygon vertices
+        poly     =  0.0 0.0 0.1 0.0 0.1 0.1 0.0 0.1   # Polygon x-y coordinates at initial time
+        bot      =  0.0                               # Polygon bottom coordinate
+        top      =  0.1                               # Polygon top coordinate
     <BCBlockEnd>
 
 # Internal velocity box(es)

--- a/src/bc.cpp
+++ b/src/bc.cpp
@@ -31,30 +31,65 @@
 //---------------------------------------------------------------------------
 PetscErrorCode BCBlockCreate(BCBlock *bcb, Scaling *scal, FB *fb)
 {
-    //	-npath - Number of path points of Bezier curve (end-points only!)
-    //	-theta - Orientation angles at path points (counter-clockwise positive)
-    //	-time  - Times at path points
-    //	-path  - path points x-y coordinates
-    //	-npoly - Number of polygon vertices
-    //	-poly  - Polygon x-y coordinates at initial time
-    //	-bot   - Polygon bottom coordinate
-    //	-top   - Polygon top coordinate
+    //	-npath    - Number of path points of Bezier curve (end-points only!)
+    //	-path_dim - Path dimension: 2 = x-y plane (default), 3 = full 3D
+    //	-theta    - Orientation angles at path points (counter-clockwise positive)
+    //	-time     - Times at path points
+    //	-path     - path points coordinates (x-y for 2D, x-y-z for 3D)
+    //	-npoly    - Number of polygon vertices
+    //	-poly     - Polygon x-y coordinates at initial time (absolute, moves with path)
+    //	-bot      - Polygon bottom z-coordinate at initial time (absolute, moves with path for 3D)
+    //	-top      - Polygon top z-coordinate at initial time (absolute, moves with path for 3D)
 
     PetscErrorCode ierr;
+    PetscInt       numPathCoords;
     PetscFunctionBeginUser;
 
-    bcb->npath = 2;
-    bcb->npoly = 4;
+    // set defaults
+    bcb->npath   = 2;
+    bcb->pathDim = 2;
+    bcb->npoly   = 4;
 
-    ierr = getIntParam   (fb, _OPTIONAL_, "npath", &bcb->npath, 1,              _max_path_points_); CHKERRQ(ierr);
-    ierr = getScalarParam(fb, _OPTIONAL_, "theta",  bcb->theta, bcb->npath,      scal->angle     ); CHKERRQ(ierr);
-    ierr = getScalarParam(fb, _REQUIRED_, "time",   bcb->time,  bcb->npath,      scal->time      ); CHKERRQ(ierr);
-    ierr = getScalarParam(fb, _REQUIRED_, "path",   bcb->path,  2*bcb->npath,    scal->length    ); CHKERRQ(ierr);
+    ierr = getIntParam   (fb, _OPTIONAL_, "npath",    &bcb->npath,   1, _max_path_points_); CHKERRQ(ierr);
+    ierr = getIntParam   (fb, _OPTIONAL_, "path_dim", &bcb->pathDim, 1, 3);                 CHKERRQ(ierr);
+
+    // validate path_dim
+    if(bcb->pathDim != 2 && bcb->pathDim != 3)
+    {
+        SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_USER, "path_dim must be 2 or 3, got: %lld", (LLD)bcb->pathDim);
+    }
+
+    // compute number of path coordinates based on dimension
+    numPathCoords = bcb->pathDim * bcb->npath;
+
+    ierr = getScalarParam(fb, _OPTIONAL_, "theta",  bcb->theta, bcb->npath,    scal->angle ); CHKERRQ(ierr);
+    ierr = getScalarParam(fb, _REQUIRED_, "time",   bcb->time,  bcb->npath,    scal->time  ); CHKERRQ(ierr);
+    ierr = getScalarParam(fb, _REQUIRED_, "path",   bcb->path,  numPathCoords, scal->length); CHKERRQ(ierr);
 
     ierr = getIntParam   (fb, _OPTIONAL_, "npoly", &bcb->npoly, 1,              _max_poly_points_); CHKERRQ(ierr);
-    ierr = getScalarParam(fb, _REQUIRED_, "poly",   bcb->poly,  2*bcb->npoly,    scal->length    ); CHKERRQ(ierr);
-    ierr = getScalarParam(fb, _REQUIRED_, "bot",   &bcb->bot,   1,               scal->length    ); CHKERRQ(ierr);
-    ierr = getScalarParam(fb, _REQUIRED_, "top",   &bcb->top,   1,               scal->length    ); CHKERRQ(ierr);
+    ierr = getScalarParam(fb, _REQUIRED_, "poly",   bcb->poly,  2*bcb->npoly,   scal->length     ); CHKERRQ(ierr);
+    ierr = getScalarParam(fb, _REQUIRED_, "bot",   &bcb->bot,   1,              scal->length     ); CHKERRQ(ierr);
+    ierr = getScalarParam(fb, _REQUIRED_, "top",   &bcb->top,   1,              scal->length     ); CHKERRQ(ierr);
+
+    PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode BCBlockPrint(BCBlock *bcb, Scaling *scal, PetscInt cnt)
+{
+    PetscFunctionBeginUser;
+
+    PetscPrintf(PETSC_COMM_WORLD, "      Bezier block #                          : %lld \n", (LLD)cnt);
+    PetscPrintf(PETSC_COMM_WORLD, "      Path dimension                          : %lld \n", (LLD)bcb->pathDim);
+    PetscPrintf(PETSC_COMM_WORLD, "      Number of path points                   : %lld \n", (LLD)bcb->npath);
+    PetscPrintf(PETSC_COMM_WORLD, "      Number of polygon vertices              : %lld \n", (LLD)bcb->npoly);
+
+    PetscPrintf(PETSC_COMM_WORLD, "      Bot/Top initial z-coordinates          : %g / %g %s \n",
+        bcb->bot*scal->length, bcb->top*scal->length, scal->lbl_length);
+
+    if(bcb->pathDim == 3)
+    {
+        PetscPrintf(PETSC_COMM_WORLD, "      (bot/top move with 3D path)            @ \n");
+    }
 
     PetscFunctionReturn(0);
 }
@@ -62,8 +97,10 @@ PetscErrorCode BCBlockCreate(BCBlock *bcb, Scaling *scal, FB *fb)
 PetscErrorCode BCBlockGetPosition(BCBlock *bcb, PetscScalar t, PetscInt *f, PetscScalar X[])
 {
     // compute position along the path and rotation angle as a function of time
+    // For 2D path (pathDim=2): X[0]=x, X[1]=y, X[2]=theta
+    // For 3D path (pathDim=3): X[0]=x, X[1]=y, X[2]=z, X[3]=theta
 
-    PetscInt      i, n;
+    PetscInt      i, n, dim;
     PetscScalar   r, s;
     PetscScalar  *p1, *p2;
     PetscScalar  *path, *theta, *time;
@@ -71,6 +108,7 @@ PetscErrorCode BCBlockGetPosition(BCBlock *bcb, PetscScalar t, PetscInt *f, Pets
     PetscFunctionBeginUser;
 
     n     = bcb->npath;
+    dim   = bcb->pathDim;
     path  = bcb->path;
     theta = bcb->theta;
     time  = bcb->time;
@@ -81,18 +119,29 @@ PetscErrorCode BCBlockGetPosition(BCBlock *bcb, PetscScalar t, PetscInt *f, Pets
     // find time interval
     for(i = 1; i < n-1; i++) { if(t < time[i]) break; } i--;
 
-    // get path and control points
-    p1 = path + 2*i;
-    p2 = p1   + 2;
+    // get path and control points (stride depends on dimension)
+    p1 = path + dim*i;
+    p2 = p1   + dim;
 
     // compute interpolation parameters
     r  = (t - time[i])/(time[i+1] - time[i]);
     s  = 1.0 - r;
 
     // interpolate path and rotation angle
-    X[0] = s*p1[0]    + r*p2[0];
-    X[1] = s*p1[1]    + r*p2[1];
-    X[2] = s*theta[i] + r*theta[i+1];
+    X[0] = s*p1[0] + r*p2[0];  // x
+    X[1] = s*p1[1] + r*p2[1];  // y
+
+    if(dim == 3)
+    {
+        // 3D path: X[0]=x, X[1]=y, X[2]=z, X[3]=theta
+        X[2] = s*p1[2]    + r*p2[2];      // z
+        X[3] = s*theta[i] + r*theta[i+1]; // theta
+    }
+    else
+    {
+        // 2D path: X[0]=x, X[1]=y, X[2]=theta
+        X[2] = s*theta[i] + r*theta[i+1]; // theta
+    }
 
 //   [A] Bezier curves can be input directly.
 //   Bezier curve requires 4 points per segment (see e.g. wikipedia):
@@ -150,21 +199,35 @@ PetscErrorCode BCBlockGetPosition(BCBlock *bcb, PetscScalar t, PetscInt *f, Pets
 //---------------------------------------------------------------------------
 PetscErrorCode BCBlockGetPolygon(BCBlock *bcb, PetscScalar Xb[], PetscScalar *cpoly)
 {
-    // compute current polygon coordinates
+    // compute current polygon coordinates (2D x-y polygon)
+    // For 2D path: Xb[0]=x, Xb[1]=y, Xb[2]=theta
+    // For 3D path: Xb[0]=x, Xb[1]=y, Xb[2]=z, Xb[3]=theta
 
-    PetscInt     i;
+    PetscInt     i, dim;
     PetscScalar *xa, *xb;
-    PetscScalar  Xa[3], theta, costh, sinth;
+    PetscScalar  Xa[4], thetaCur, thetaInit, theta, costh, sinth;
 
     PetscFunctionBeginUser;
 
-    // get initial polygon position
+    dim = bcb->pathDim;
+
+    // get initial polygon position (x, y only for 2D rotation)
     Xa[0] = bcb->path[0];
     Xa[1] = bcb->path[1];
-    Xa[2] = bcb->theta[0];
+    thetaInit = bcb->theta[0];
 
-    // get rotation matrix
-    theta = Xb[2] - Xa[2];
+    // get current rotation angle (theta is at different index for 2D vs 3D)
+    if(dim == 3)
+    {
+        thetaCur = Xb[3];
+    }
+    else
+    {
+        thetaCur = Xb[2];
+    }
+
+    // get rotation matrix (rotation around z-axis)
+    theta = thetaCur - thetaInit;
     costh = cos(theta);
     sinth = sin(theta);
 
@@ -175,7 +238,7 @@ PetscErrorCode BCBlockGetPolygon(BCBlock *bcb, PetscScalar Xb[], PetscScalar *cp
         xa = bcb->poly + 2*i;
         xb = cpoly     + 2*i;
 
-        // rotate & displace
+        // rotate & displace (2D rotation in x-y plane)
         RotDispPoint2D(Xa, Xb, costh, sinth, xa, xb);
     }
 
@@ -687,6 +750,12 @@ PetscErrorCode BCCreate(BCCtx *bc, FB *fb)
     if(bc->ExxNumPeriods)    PetscPrintf(PETSC_COMM_WORLD, "   Number of x-background strain rate periods : %lld \n",  (LLD)bc->ExxNumPeriods);
     if(bc->EyyNumPeriods)    PetscPrintf(PETSC_COMM_WORLD, "   Number of y-background strain rate periods : %lld \n",  (LLD)bc->EyyNumPeriods);
     if(bc->nblocks)          PetscPrintf(PETSC_COMM_WORLD, "   Number of Bezier blocks                    : %lld \n",  (LLD)bc->nblocks);
+
+    for(jj = 0; jj < bc->nblocks; jj++)
+    {
+        ierr = BCBlockPrint(bc->blocks + jj, scal, jj); CHKERRQ(ierr);
+    }
+
     if(bc->nboxes)           PetscPrintf(PETSC_COMM_WORLD, "   Number of velocity boxes                   : %lld \n",  (LLD)bc->nboxes);
 
     for(jj = 0; jj < bc->nboxes; jj++)
@@ -1567,11 +1636,11 @@ PetscErrorCode BCApplyBezier(BCCtx *bc)
 {
     FDSTAG      *fs;
     BCBlock     *bcb;
-    PetscInt    fbeg, fend, npoly, in;
+    PetscInt    fbeg, fend, npoly, in, dim;
     PetscInt    i, j, k, nx, ny, nz, sx, sy, sz, iter, ib;
-    PetscScalar ***bcvx,  ***bcvy;
-    PetscScalar t, dt, theta, costh, sinth, atol, bot, top, vel;
-    PetscScalar Xbeg[3], Xend[3], xbeg[3], xend[3], box[4], cpoly[2*_max_poly_points_];
+    PetscScalar ***bcvx, ***bcvy, ***bcvz;
+    PetscScalar t, dt, theta, costh, sinth, atol, bot, top, vel, zOffset, velz;
+    PetscScalar Xbeg[4], Xend[4], xbeg[3], xend[3], box[4], cpoly[2*_max_poly_points_];
 
     PetscErrorCode ierr;
     PetscFunctionBeginUser;
@@ -1587,13 +1656,13 @@ PetscErrorCode BCApplyBezier(BCCtx *bc)
     // access velocity constraint vectors
     ierr = DMDAVecGetArray(fs->DA_X, bc->bcvx, &bcvx); CHKERRQ(ierr);
     ierr = DMDAVecGetArray(fs->DA_Y, bc->bcvy, &bcvy); CHKERRQ(ierr);
+    ierr = DMDAVecGetArray(fs->DA_Z, bc->bcvz, &bcvz); CHKERRQ(ierr);
 
     // loop over all bezier blocks
     for(ib = 0; ib < bc->nblocks; ib++)
     {
         bcb   =  bc->blocks + ib;
-        bot   =  bcb->bot;
-        top   =  bcb->top;
+        dim   =  bcb->pathDim;
         npoly =  bcb->npoly;
 
         // get polygon positions in the beginning & end of the time step
@@ -1603,6 +1672,25 @@ PetscErrorCode BCApplyBezier(BCCtx *bc)
         // check whether constraint applies to the current time step
         if(!fbeg || !fend) continue;
 
+        // compute bot/top z-coordinates
+        // For 2D path: bot/top are absolute z-coordinates (no z-movement)
+        // For 3D path: bot/top are initial absolute z-coordinates that move with the path
+        //              (same as polygon x-y vertices which are also initial absolute)
+        if(dim == 3)
+        {
+            // compute z-displacement from initial path position (same logic as polygon x-y)
+            zOffset = Xbeg[2] - bcb->path[2];  // current_path_z - initial_path_z
+            bot     = bcb->bot + zOffset;
+            top     = bcb->top + zOffset;
+            velz    = (Xend[2] - Xbeg[2])/dt;  // z-velocity
+        }
+        else
+        {
+            bot  = bcb->bot;
+            top  = bcb->top;
+            velz = 0.0;
+        }
+
         // get current polygon geometry
         ierr = BCBlockGetPolygon(bcb, Xbeg, cpoly);
 
@@ -1610,7 +1698,15 @@ PetscErrorCode BCApplyBezier(BCCtx *bc)
         polygon_box(&npoly, cpoly, 1e-12, &atol, box);
 
         // get time step rotation matrix
-        theta = Xend[2] - Xbeg[2];
+        // theta is at index 2 for 2D path, index 3 for 3D path
+        if(dim == 3)
+        {
+            theta = Xend[3] - Xbeg[3];
+        }
+        else
+        {
+            theta = Xend[2] - Xbeg[2];
+        }
         costh = cos(theta);
         sinth = sin(theta);
 
@@ -1685,10 +1781,44 @@ PetscErrorCode BCApplyBezier(BCCtx *bc)
             iter++;
         }
         END_STD_LOOP
+
+        //---------
+        // Z points (only for 3D path)
+        //---------
+        if(dim == 3)
+        {
+            GET_CELL_RANGE(nx, sx, fs->dsx)
+            GET_CELL_RANGE(ny, sy, fs->dsy)
+            GET_NODE_RANGE(nz, sz, fs->dsz)
+
+            START_STD_LOOP
+            {
+                // get node coordinates in the beginning of time step
+                xbeg[0] = COORD_CELL(i, sx, fs->dsx);
+                xbeg[1] = COORD_CELL(j, sy, fs->dsy);
+                xbeg[2] = COORD_NODE(k, sz, fs->dsz);
+
+                // perform point test
+                if(xbeg[2] >= bot && xbeg[2] <= top)
+                {
+                    in_polygon(1, xbeg, npoly, cpoly, box, atol, &in);
+
+                    // check whether point is inside polygon
+                    if(in)
+                    {
+                        // set z-velocity (uniform for the block)
+                        bcvz[k][j][i] = velz;
+                    }
+                }
+                iter++;
+            }
+            END_STD_LOOP
+        }
     }
     // restore access
     ierr = DMDAVecRestoreArray(fs->DA_X, bc->bcvx, &bcvx); CHKERRQ(ierr);
     ierr = DMDAVecRestoreArray(fs->DA_Y, bc->bcvy, &bcvy); CHKERRQ(ierr);
+    ierr = DMDAVecRestoreArray(fs->DA_Z, bc->bcvz, &bcvz); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
 }

--- a/src/bc.h
+++ b/src/bc.h
@@ -39,14 +39,15 @@ struct BCBlock
 {
 	// path description
 	PetscInt    npath;                        // number of path points of Bezier curve
+	PetscInt    pathDim;                      // path dimension (2 = x-y plane, 3 = full 3D)
 	PetscScalar theta[  _max_path_points_  ]; // orientation angles at path points
 	PetscScalar time [  _max_path_points_  ]; // times at path points
-	PetscScalar path [6*_max_path_points_-4]; // Bezier curve path & control points (3*n-2)
+	PetscScalar path [9*_max_path_points_-6]; // Bezier curve path & control points (3*n-2 points, up to 3 coords each)
 
 	// block description
 	PetscInt    npoly;                      // number of polygon vertices
 	PetscScalar poly [2*_max_poly_points_]; // polygon coordinates
-	PetscScalar bot, top;                   // bottom & top coordinates of the block
+	PetscScalar bot, top;                   // bottom & top z-coordinates at initial time (move with path for 3D)
 
 	// WARNING bottom coordinate should be advected (how? average?)
 	// Top of the box can be assumed to be the free surface
@@ -59,10 +60,15 @@ struct BCBlock
 // setup data structures
 PetscErrorCode BCBlockCreate(BCBlock *bcb, Scaling *scal, FB *fb);
 
+// print Bezier block summary
+PetscErrorCode BCBlockPrint(BCBlock *bcb, Scaling *scal, PetscInt cnt);
+
 // compute position along the path and rotation angle as a function of time
+// For 2D path: x[0]=x, x[1]=y, x[2]=theta
+// For 3D path: x[0]=x, x[1]=y, x[2]=z, x[3]=theta
 PetscErrorCode BCBlockGetPosition(BCBlock *bcb, PetscScalar t, PetscInt *f, PetscScalar x[]);
 
-// compute current polygon coordinates
+// compute current polygon coordinates (2D x-y polygon, z handled separately in BCApplyBezier)
 PetscErrorCode BCBlockGetPolygon(BCBlock *bcb, PetscScalar Xb[], PetscScalar *cpoly);
 
 //---------------------------------------------------------------------------

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1095,5 +1095,24 @@ end
     clean_test_directory(dir)
 end
 
+
+@testset "t34_3D_2D_push_block" begin
+    cd(test_dir)
+    dir = "t34_3D_2D_push_block";
+    
+    ParamFile = "3D_push_block.dat";
+    
+    keywords = ("|Div|_inf","|Div|_2","|mRes|_2")
+    acc      = ((rtol=1e-6,atol=1e-10), (rtol=1e-5,atol=1e-10), (rtol=1e-4,atol=1e-10));
+    
+    # Test 3D Bezier push block functionality
+    @test perform_lamem_test(dir,ParamFile,"3D_push_block_opt-p1.expected", 
+                            keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec)
+
+    # Test 2D Bezier push block functionality (push along x-axis only)
+    ParamFile = "2D_push_block.dat";
+    @test perform_lamem_test(dir,ParamFile,"2D_push_block_opt-p1.expected", 
+                            keywords=keywords, accuracy=acc, cores=1, opt=true, mpiexec=mpiexec)
 end
 
+end

--- a/test/t34_3D_2D_push_block/2D_push_block.dat
+++ b/test/t34_3D_2D_push_block/2D_push_block.dat
@@ -1,0 +1,161 @@
+#===============================================================================
+# Test for 2D Bezier push block functionality (push along x-axis only)
+# Based on 3D push block test, with 2D push parameters
+#===============================================================================
+
+#===============================================================================
+# Scaling
+#===============================================================================
+
+	units = none
+
+#===============================================================================
+# Time stepping parameters
+#===============================================================================
+
+	time_end  = 1.0   # simulation end time
+	dt        = 1e-2  # time step
+	dt_min    = 1e-5  # minimum time step (declare divergence if lower value is attempted)
+	dt_max    = 0.1   # maximum time step
+	dt_out    = 0.2   # output step (output at least at fixed time intervals)
+	inc_dt    = 0.1   # time step increment per time step (fraction of unit)
+	CFL       = 0.5   # CFL (Courant-Friedrichs-Lewy) criterion
+	CFLMAX    = 0.5   # CFL criterion for elasticity
+	nstep_max = 10     # maximum allowed number of steps (lower bound: time_end/dt_max)
+	nstep_out = 1     # save output every n steps
+	nstep_rdb = 0     # save restart database every n steps
+
+
+#===============================================================================
+# Grid & discretization parameters
+#===============================================================================
+
+# Number of cells for all segments
+
+	nel_x = 16
+	nel_y = 16
+	nel_z = 16
+
+# Coordinates of all segments (including start and end points)
+
+	coord_x = 0.0 1.0
+	coord_y = 0.0 1.0
+	coord_z = 0.0 1.0
+
+#===============================================================================
+# Free surface
+#===============================================================================
+
+# Default
+
+#===============================================================================
+# Boundary conditions
+#===============================================================================
+
+# 2D Bezier push block - pushes the block rightward (x+) only
+# The polygon covers the full x-y extent of the falling block (0.25-0.75 in both x and y)
+# Path starts at block center (0.5, 0.5) and moves to (0.7, 0.5) over time 0-1
+# This creates x velocity (+0.2/1.0 = 0.2), z stays constant
+
+	<BCBlockStart>
+		npath    = 2                                    # Number of path points
+		path_dim = 2                                    # 2D path (x, z)
+		theta    = 0.0 0.0                              # No rotation
+		time     = 0.0 1.0                              # Time interval
+		path     = 0.5 0.5   0.7 0.5                    # Path: x moves 0.5 -> 0.7, z stays at 0.5
+		npoly    = 4                                    # Square polygon matching block x-y extent
+		poly     = 0.25 0.25  0.75 0.25  0.75 0.75  0.25 0.75   # Square covering block (0.25-0.75 in x,y)
+		bot      = 0.25                                 # Initial z bottom (same as block)
+		top      = 0.75                                 # Initial z top (same as block)
+	<BCBlockEnd>
+
+#===============================================================================
+# Solution parameters & controls
+#===============================================================================
+
+	gravity        = 0.0 0.0 -1.0   # gravity vector
+	FSSA           = 1.0            # free surface stabilization parameter [0 - 1]
+	init_guess     = 0              # initial guess flag
+	eta_min        = 1e-3           # viscosity upper bound
+	eta_max        = 1e12           # viscosity lower limit
+
+#===============================================================================
+# Solver options
+#===============================================================================
+	SolverType 		=	direct 			# solver [direct or multigrid]
+	DirectSolver 	=	mumps			# mumps/superlu_dist/pastix
+	DirectPenalty 	=	1e5
+
+
+#===============================================================================
+# Model setup & advection
+#===============================================================================
+
+	msetup         = geom              # setup type
+	nmark_x        = 2                 # markers per cell in x-direction
+	nmark_y        = 2                 # ...                 y-direction
+	nmark_z        = 2                 # ...                 z-direction
+	bg_phase       = 0                 # background phase ID
+
+
+# Geometric primitives - a block that will be pushed
+
+	<HexStart>
+		phase  = 1
+		coord = 0.25 0.25 0.25   0.75 0.25 0.25   0.75 0.75 0.25   0.25 0.75 0.25   0.25 0.25 0.75   0.75 0.25 0.75   0.75 0.75 0.75   0.25 0.75 0.75
+	<HexEnd>
+
+#===============================================================================
+# Output
+#===============================================================================
+
+# Grid output options (output is always active)
+
+	out_file_name       = 2D_push_test # output file name
+	out_pvd             = 1            # activate writing .pvd file
+
+# AVD phase viewer output options (requires activation)
+
+	out_avd     = 1 # activate AVD phase output
+	out_avd_pvd = 1 # activate writing .pvd file
+	out_avd_ref = 3 # AVD grid refinement factor
+
+#===============================================================================
+# Material phase parameters
+#===============================================================================
+
+	# Define properties of matrix
+	<MaterialStart>
+		ID  = 0 # phase id
+		rho = 1 # density
+		eta = 1 # viscosity
+	<MaterialEnd>
+
+	# Define properties of block
+	<MaterialStart>
+		ID  = 1   # phase id
+		rho = 2   # density
+		eta = 100 # viscosity
+	<MaterialEnd>
+
+#===============================================================================
+# PETSc options
+#===============================================================================
+
+<PetscOptionsStart>
+
+	# LINEAR & NONLINEAR SOLVER OPTIONS
+	-snes_type ksponly # no nonlinear solver
+
+	# Jacobian (linear) outer KSP
+	-js_ksp_type gmres
+	-js_ksp_max_it 25
+	-js_ksp_monitor
+	-js_ksp_rtol 1e-4
+	-js_ksp_atol 1e-10
+
+	-objects_dump
+
+<PetscOptionsEnd>
+
+#===============================================================================

--- a/test/t34_3D_2D_push_block/2D_push_block_opt-p1.expected
+++ b/test/t34_3D_2D_push_block/2D_push_block_opt-p1.expected
@@ -1,0 +1,403 @@
+-------------------------------------------------------------------------- 
+                   Lithosphere and Mantle Evolution Model                   
+     Compiled: Date: Feb  1 2026 - Time: 10:50:55 	    
+     Version : 2.2.0 
+-------------------------------------------------------------------------- 
+        STAGGERED-GRID FINITE DIFFERENCE CANONICAL IMPLEMENTATION           
+-------------------------------------------------------------------------- 
+Parsing input file : 2D_push_block.dat 
+   Adding PETSc option: -snes_type ksponly
+   Adding PETSc option: -js_ksp_type gmres
+   Adding PETSc option: -js_ksp_max_it 25
+   Adding PETSc option: -js_ksp_monitor
+   Adding PETSc option: -js_ksp_rtol 1e-4
+   Adding PETSc option: -js_ksp_atol 1e-10
+   Adding PETSc option: -objects_dump
+Finished parsing input file 
+--------------------------------------------------------------------------
+Time stepping parameters:
+   Simulation end time          : 1. [ ] 
+   Maximum number of steps      : 10 
+   Time step                    : 0.01 [ ] 
+   Minimum time step            : 1e-05 [ ] 
+   Maximum time step            : 0.1 [ ] 
+   Time step increase factor    : 0.1 
+   CFL criterion                : 0.5 
+   CFLMAX (fixed time steps)    : 0.5 
+   Output time step             : 0.2 [ ] 
+   Output every [n] steps       : 1 
+   Output [n] initial steps     : 1 
+--------------------------------------------------------------------------
+Grid parameters:
+   Total number of cpu                  : 1 
+   Processor grid  [nx, ny, nz]         : [1, 1, 1]
+   Fine grid cells [nx, ny, nz]         : [16, 16, 16]
+   Number of cells                      :  4096
+   Number of faces                      :  13056
+   Maximum cell aspect ratio            :  1.00000
+   Lower coordinate bounds [bx, by, bz] : [0., 0., 0.]
+   Upper coordinate bounds [ex, ey, ez] : [1., 1., 1.]
+--------------------------------------------------------------------------
+--------------------------------------------------------------------------
+Material parameters: 
+--------------------------------------------------------------------------
+   Phase ID : 0   
+   (dens)   : rho = 1. [ ]  
+   (diff)   : eta = 1. [ ]  Bd = 0.5 [ ]  
+
+   Phase ID : 1   
+   (dens)   : rho = 2. [ ]  
+   (diff)   : eta = 100. [ ]  Bd = 0.005 [ ]  
+
+--------------------------------------------------------------------------
+--------------------------------------------------------------------------
+Boundary condition parameters: 
+   No-slip boundary mask [lt rt ft bk bm tp]  : 0 0 0 0 0 0 
+   Number of Bezier blocks                    : 1 
+      Bezier block #                          : 0 
+      Path dimension                          : 2 
+      Number of path points                   : 2 
+      Number of polygon vertices              : 4 
+      Bot/Top initial z-coordinates          : 0.25 / 0.75 [ ] 
+--------------------------------------------------------------------------
+Solution parameters & controls:
+   Gravity [gx, gy, gz]                    : [0., 0., -1.] [ ] 
+   Surface stabilization (FSSA)            :  1. 
+   Use lithostatic pressure for creep      @ 
+   Minimum viscosity                       : 0.001 [ ] 
+   Maximum viscosity                       : 1e+12 [ ] 
+   Max. melt fraction (viscosity, density) : 1.    
+   Rheology iteration number               : 25  
+   Rheology iteration tolerance            : 1e-06    
+   Ground water level type                 : none 
+--------------------------------------------------------------------------
+Advection parameters:
+   Advection scheme              : Euler 1-st order (basic implementation)
+   Periodic marker advection     : 0 0 0 
+   Marker setup scheme           : geometric primitives
+   Velocity interpolation scheme : STAG (linear)
+   Marker control type           : no marker control
+   Markers per cell [nx, ny, nz] : [2, 2, 2] 
+   Marker distribution type      : uniform
+   Background phase ID           : 0 
+--------------------------------------------------------------------------
+Reading geometric primitives ... done (0.000752027 sec)
+--------------------------------------------------------------------------
+Output parameters:
+   Output file name                        : 2D_push_test 
+   Write .pvd file                         : yes 
+   Phase                                   @ 
+   Total effective viscosity               @ 
+   Creep effective viscosity               @ 
+   Velocity                                @ 
+   Pressure                                @ 
+--------------------------------------------------------------------------
+AVD output parameters:
+   Write .pvd file       : yes 
+   AVD refinement factor : 3 
+--------------------------------------------------------------------------
+Preconditioner parameters: 
+   Matrix type                   : monolithic
+   Penalty parameter (pgamma)    : 1.000000e+05
+   Preconditioner type           : user-defined
+--------------------------------------------------------------------------
+Solver parameters specified: 
+   Outermost Krylov solver       : gmres 
+   Solver type                   : serial direct/lu 
+   Solver package                : petsc 
+--------------------------------------------------------------------------
+Saving output ... done (0.0421015 sec)
+--------------------------------------------------------------------------
+================================= STEP 1 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00000000 [ ] 
+Tentative time step : 0.01000000 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.202826625477e+04
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 2.626469222896e+02
+    1 KSP Residual norm 1.497815832270e-02
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.620345023807e+00
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.38404 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.294363261784e-04 
+      |Div|_2   = 3.841562339073e-03 
+   Momentum: 
+      |mRes|_2  = 4.620343426783e+00 
+--------------------------------------------------------------------------
+Actual time step : 0.01000 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0485139 sec)
+--------------------------------------------------------------------------
+================================= STEP 2 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01000000 [ ] 
+Tentative time step : 0.01100000 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.527089474506e+03
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 1.360246194746e+02
+    1 KSP Residual norm 7.487667578516e-03
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.107203676126e-01
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.27111 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.213848308648e-06 
+      |Div|_2   = 2.836742457217e-05 
+   Momentum: 
+      |mRes|_2  = 1.107203639786e-01 
+--------------------------------------------------------------------------
+Actual time step : 0.01100 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0492828 sec)
+--------------------------------------------------------------------------
+================================= STEP 3 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02100000 [ ] 
+Tentative time step : 0.01210000 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 5.792097162147e+01
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 6.190200210426e-01
+    1 KSP Residual norm 4.404765454202e-05
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.784017626428e-03
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.31622 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.873464224397e-07 
+      |Div|_2   = 2.631574140961e-06 
+   Momentum: 
+      |mRes|_2  = 3.784016711371e-03 
+--------------------------------------------------------------------------
+Actual time step : 0.01210 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0505387 sec)
+--------------------------------------------------------------------------
+================================= STEP 4 =================================
+--------------------------------------------------------------------------
+Current time        : 0.03310000 [ ] 
+Tentative time step : 0.01331000 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.493478621494e+01
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 7.078284802273e-01
+    1 KSP Residual norm 4.767880569350e-05
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.025732154998e-03
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.27458 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.771003591670e-07 
+      |Div|_2   = 2.953685552690e-06 
+   Momentum: 
+      |mRes|_2  = 4.025731071436e-03 
+--------------------------------------------------------------------------
+Actual time step : 0.01331 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0521719 sec)
+--------------------------------------------------------------------------
+================================= STEP 5 =================================
+--------------------------------------------------------------------------
+Current time        : 0.04641000 [ ] 
+Tentative time step : 0.01464100 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.325018378520e+01
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 8.218557070315e-01
+    1 KSP Residual norm 5.168710384604e-05
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.262217567518e-03
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.28462 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 6.904587860346e-07 
+      |Div|_2   = 3.367711675979e-06 
+   Momentum: 
+      |mRes|_2  = 4.262216237050e-03 
+--------------------------------------------------------------------------
+Actual time step : 0.01464 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0528225 sec)
+--------------------------------------------------------------------------
+================================= STEP 6 =================================
+--------------------------------------------------------------------------
+Current time        : 0.06105100 [ ] 
+Tentative time step : 0.01610510 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 8.319689734708e+01
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 9.708525852977e-01
+    1 KSP Residual norm 5.666764764502e-05
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.536213084463e-03
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.27846 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 8.365024303236e-07 
+      |Div|_2   = 3.915321171524e-06 
+   Momentum: 
+      |mRes|_2  = 4.536211394756e-03 
+--------------------------------------------------------------------------
+Actual time step : 0.01611 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0527157 sec)
+--------------------------------------------------------------------------
+================================= STEP 7 =================================
+--------------------------------------------------------------------------
+Current time        : 0.07715610 [ ] 
+Tentative time step : 0.01771561 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 9.528496178132e+01
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 1.170108987724e+00
+    1 KSP Residual norm 6.323549684843e-05
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.868326191774e-03
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.28071 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.028938514946e-06 
+      |Div|_2   = 4.659642943489e-06 
+   Momentum: 
+      |mRes|_2  = 4.868323961821e-03 
+--------------------------------------------------------------------------
+Actual time step : 0.01772 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0541765 sec)
+--------------------------------------------------------------------------
+================================= STEP 8 =================================
+--------------------------------------------------------------------------
+Current time        : 0.09487171 [ ] 
+Tentative time step : 0.01948717 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 8.131063848324e+03
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 8.002537832578e+01
+    1 KSP Residual norm 5.692806167178e-03
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.643587955377e-01
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.28936 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.757966214624e-05 
+      |Div|_2   = 3.033738532769e-04 
+   Momentum: 
+      |mRes|_2  = 5.643587139977e-01 
+--------------------------------------------------------------------------
+Actual time step : 0.01949 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0553157 sec)
+--------------------------------------------------------------------------
+================================= STEP 9 =================================
+--------------------------------------------------------------------------
+Current time        : 0.11435888 [ ] 
+Tentative time step : 0.02143589 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.875105448160e+02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 1.129370331605e+01
+    1 KSP Residual norm 1.049982080981e-03
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.961236516091e-02
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.27354 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.220073933794e-05 
+      |Div|_2   = 4.781370696342e-05 
+   Momentum: 
+      |mRes|_2  = 5.961234598577e-02 
+--------------------------------------------------------------------------
+Actual time step : 0.02144 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0546812 sec)
+--------------------------------------------------------------------------
+================================ STEP 10 =================================
+--------------------------------------------------------------------------
+Current time        : 0.13579477 [ ] 
+Tentative time step : 0.02357948 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.024147223169e+02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 6.773369347576e+00
+    1 KSP Residual norm 5.237118175259e-04
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 2.977004887491e-02
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.2877 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.040804739478e-06 
+      |Div|_2   = 1.273319474509e-05 
+   Momentum: 
+      |mRes|_2  = 2.977004615179e-02 
+--------------------------------------------------------------------------
+Actual time step : 0.02358 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0547407 sec)
+--------------------------------------------------------------------------
+=========================== SOLUTION IS DONE! ============================
+--------------------------------------------------------------------------
+Total solution time : 13.6615 (sec) 
+--------------------------------------------------------------------------
+WARNING! There are options you set that were not used!
+WARNING! could be spelling mistake, etc!
+There are 6 unused database options. They are:
+Option left: name:-mat_product_algorithm value: scalable source: code
+Option left: name:-matmatmatmult_via value: scalable source: code
+Option left: name:-matmatmult_via value: scalable source: code
+Option left: name:-ParamFile value: 2D_push_block.dat source: code
+Option left: name:-snes_linesearch_maxstep value: 1.0 source: code
+Option left: name:-snes_linesearch_type value: basic source: code

--- a/test/t34_3D_2D_push_block/3D_push_block.dat
+++ b/test/t34_3D_2D_push_block/3D_push_block.dat
@@ -1,0 +1,161 @@
+#===============================================================================
+# Test for 3D Bezier push block functionality
+# Based on FallingBlock test with added 3D push block
+#===============================================================================
+
+#===============================================================================
+# Scaling
+#===============================================================================
+
+	units = none
+
+#===============================================================================
+# Time stepping parameters
+#===============================================================================
+
+	time_end  = 1.0   # simulation end time
+	dt        = 1e-2  # time step
+	dt_min    = 1e-5  # minimum time step (declare divergence if lower value is attempted)
+	dt_max    = 0.1   # maximum time step
+	dt_out    = 0.2   # output step (output at least at fixed time intervals)
+	inc_dt    = 0.1   # time step increment per time step (fraction of unit)
+	CFL       = 0.5   # CFL (Courant-Friedrichs-Lewy) criterion
+	CFLMAX    = 0.5   # CFL criterion for elasticity
+	nstep_max = 10     # maximum allowed number of steps (lower bound: time_end/dt_max)
+	nstep_out = 1     # save output every n steps
+	nstep_rdb = 0     # save restart database every n steps
+
+
+#===============================================================================
+# Grid & discretization parameters
+#===============================================================================
+
+# Number of cells for all segments
+
+	nel_x = 16
+	nel_y = 16
+	nel_z = 16
+
+# Coordinates of all segments (including start and end points)
+
+	coord_x = 0.0 1.0
+	coord_y = 0.0 1.0
+	coord_z = 0.0 1.0
+
+#===============================================================================
+# Free surface
+#===============================================================================
+
+# Default
+
+#===============================================================================
+# Boundary conditions
+#===============================================================================
+
+# 3D Bezier push block - pushes the entire block rightward (x+) and upward (z+)
+# The polygon covers the full x-y extent of the falling block (0.25-0.75 in both x and y)
+# Path starts at block center (0.5, 0.5, 0.5) and moves to (0.7, 0.5, 0.7) over time 0-1
+# This creates x,y,z velocities (+0.2/1.0 = 0.2 in each direction)
+
+	<BCBlockStart>
+		npath    = 2                                    # Number of path points
+		path_dim = 3                                    # 3D path (x, y, z)
+		theta    = 0.0 0.0                              # No rotation
+		time     = 0.0 1.0                              # Time interval
+		path     = 0.5 0.5 0.5   0.7 0.7 0.7            # Path: (0.5,0.5,0.5) -> (0.7,0.7,0.7)
+		npoly    = 4                                    # Square polygon matching block x-y extent
+		poly     = 0.25 0.25  0.75 0.25  0.75 0.75  0.25 0.75   # Square covering block (0.25-0.75 in x,y)
+		bot      = 0.25                                 # Initial z bottom (same as block)
+		top      = 0.75                                 # Initial z top (same as block)
+	<BCBlockEnd>
+
+#===============================================================================
+# Solution parameters & controls
+#===============================================================================
+
+	gravity        = 0.0 0.0 -1.0   # gravity vector
+	FSSA           = 1.0            # free surface stabilization parameter [0 - 1]
+	init_guess     = 0              # initial guess flag
+	eta_min        = 1e-3           # viscosity upper bound
+	eta_max        = 1e12           # viscosity lower limit
+
+#===============================================================================
+# Solver options
+#===============================================================================
+	SolverType 		=	direct 			# solver [direct or multigrid]
+	DirectSolver 	=	mumps			# mumps/superlu_dist/pastix
+	DirectPenalty 	=	1e5
+
+
+#===============================================================================
+# Model setup & advection
+#===============================================================================
+
+	msetup         = geom              # setup type
+	nmark_x        = 2                 # markers per cell in x-direction
+	nmark_y        = 2                 # ...                 y-direction
+	nmark_z        = 2                 # ...                 z-direction
+	bg_phase       = 0                 # background phase ID
+
+
+# Geometric primitives - a block that will be pushed
+
+	<HexStart>
+		phase  = 1
+		coord = 0.25 0.25 0.25   0.75 0.25 0.25   0.75 0.75 0.25   0.25 0.75 0.25   0.25 0.25 0.75   0.75 0.25 0.75   0.75 0.75 0.75   0.25 0.75 0.75
+	<HexEnd>
+
+#===============================================================================
+# Output
+#===============================================================================
+
+# Grid output options (output is always active)
+
+	out_file_name       = 3D_push_test # output file name
+	out_pvd             = 1            # activate writing .pvd file
+
+# AVD phase viewer output options (requires activation)
+
+	out_avd     = 1 # activate AVD phase output
+	out_avd_pvd = 1 # activate writing .pvd file
+	out_avd_ref = 3 # AVD grid refinement factor
+
+#===============================================================================
+# Material phase parameters
+#===============================================================================
+
+	# Define properties of matrix
+	<MaterialStart>
+		ID  = 0 # phase id
+		rho = 1 # density
+		eta = 1 # viscosity
+	<MaterialEnd>
+
+	# Define properties of block
+	<MaterialStart>
+		ID  = 1   # phase id
+		rho = 2   # density
+		eta = 100 # viscosity
+	<MaterialEnd>
+
+#===============================================================================
+# PETSc options
+#===============================================================================
+
+<PetscOptionsStart>
+
+	# LINEAR & NONLINEAR SOLVER OPTIONS
+	-snes_type ksponly # no nonlinear solver
+
+	# Jacobian (linear) outer KSP
+	-js_ksp_type gmres
+	-js_ksp_max_it 25
+	-js_ksp_monitor
+	-js_ksp_rtol 1e-4
+	-js_ksp_atol 1e-10
+
+	-objects_dump
+
+<PetscOptionsEnd>
+
+#===============================================================================

--- a/test/t34_3D_2D_push_block/3D_push_block_opt-p1.expected
+++ b/test/t34_3D_2D_push_block/3D_push_block_opt-p1.expected
@@ -1,0 +1,404 @@
+-------------------------------------------------------------------------- 
+                   Lithosphere and Mantle Evolution Model                   
+     Compiled: Date: Feb  1 2026 - Time: 10:50:55 	    
+     Version : 2.2.0 
+-------------------------------------------------------------------------- 
+        STAGGERED-GRID FINITE DIFFERENCE CANONICAL IMPLEMENTATION           
+-------------------------------------------------------------------------- 
+Parsing input file : 3D_push_block.dat 
+   Adding PETSc option: -snes_type ksponly
+   Adding PETSc option: -js_ksp_type gmres
+   Adding PETSc option: -js_ksp_max_it 25
+   Adding PETSc option: -js_ksp_monitor
+   Adding PETSc option: -js_ksp_rtol 1e-4
+   Adding PETSc option: -js_ksp_atol 1e-10
+   Adding PETSc option: -objects_dump
+Finished parsing input file 
+--------------------------------------------------------------------------
+Time stepping parameters:
+   Simulation end time          : 1. [ ] 
+   Maximum number of steps      : 10 
+   Time step                    : 0.01 [ ] 
+   Minimum time step            : 1e-05 [ ] 
+   Maximum time step            : 0.1 [ ] 
+   Time step increase factor    : 0.1 
+   CFL criterion                : 0.5 
+   CFLMAX (fixed time steps)    : 0.5 
+   Output time step             : 0.2 [ ] 
+   Output every [n] steps       : 1 
+   Output [n] initial steps     : 1 
+--------------------------------------------------------------------------
+Grid parameters:
+   Total number of cpu                  : 1 
+   Processor grid  [nx, ny, nz]         : [1, 1, 1]
+   Fine grid cells [nx, ny, nz]         : [16, 16, 16]
+   Number of cells                      :  4096
+   Number of faces                      :  13056
+   Maximum cell aspect ratio            :  1.00000
+   Lower coordinate bounds [bx, by, bz] : [0., 0., 0.]
+   Upper coordinate bounds [ex, ey, ez] : [1., 1., 1.]
+--------------------------------------------------------------------------
+--------------------------------------------------------------------------
+Material parameters: 
+--------------------------------------------------------------------------
+   Phase ID : 0   
+   (dens)   : rho = 1. [ ]  
+   (diff)   : eta = 1. [ ]  Bd = 0.5 [ ]  
+
+   Phase ID : 1   
+   (dens)   : rho = 2. [ ]  
+   (diff)   : eta = 100. [ ]  Bd = 0.005 [ ]  
+
+--------------------------------------------------------------------------
+--------------------------------------------------------------------------
+Boundary condition parameters: 
+   No-slip boundary mask [lt rt ft bk bm tp]  : 0 0 0 0 0 0 
+   Number of Bezier blocks                    : 1 
+      Bezier block #                          : 0 
+      Path dimension                          : 3 
+      Number of path points                   : 2 
+      Number of polygon vertices              : 4 
+      Bot/Top initial z-coordinates          : 0.25 / 0.75 [ ] 
+      (bot/top move with 3D path)            @ 
+--------------------------------------------------------------------------
+Solution parameters & controls:
+   Gravity [gx, gy, gz]                    : [0., 0., -1.] [ ] 
+   Surface stabilization (FSSA)            :  1. 
+   Use lithostatic pressure for creep      @ 
+   Minimum viscosity                       : 0.001 [ ] 
+   Maximum viscosity                       : 1e+12 [ ] 
+   Max. melt fraction (viscosity, density) : 1.    
+   Rheology iteration number               : 25  
+   Rheology iteration tolerance            : 1e-06    
+   Ground water level type                 : none 
+--------------------------------------------------------------------------
+Advection parameters:
+   Advection scheme              : Euler 1-st order (basic implementation)
+   Periodic marker advection     : 0 0 0 
+   Marker setup scheme           : geometric primitives
+   Velocity interpolation scheme : STAG (linear)
+   Marker control type           : no marker control
+   Markers per cell [nx, ny, nz] : [2, 2, 2] 
+   Marker distribution type      : uniform
+   Background phase ID           : 0 
+--------------------------------------------------------------------------
+Reading geometric primitives ... done (0.00124931 sec)
+--------------------------------------------------------------------------
+Output parameters:
+   Output file name                        : 3D_push_test 
+   Write .pvd file                         : yes 
+   Phase                                   @ 
+   Total effective viscosity               @ 
+   Creep effective viscosity               @ 
+   Velocity                                @ 
+   Pressure                                @ 
+--------------------------------------------------------------------------
+AVD output parameters:
+   Write .pvd file       : yes 
+   AVD refinement factor : 3 
+--------------------------------------------------------------------------
+Preconditioner parameters: 
+   Matrix type                   : monolithic
+   Penalty parameter (pgamma)    : 1.000000e+05
+   Preconditioner type           : user-defined
+--------------------------------------------------------------------------
+Solver parameters specified: 
+   Outermost Krylov solver       : gmres 
+   Solver type                   : serial direct/lu 
+   Solver package                : petsc 
+--------------------------------------------------------------------------
+Saving output ... done (0.0463249 sec)
+--------------------------------------------------------------------------
+================================= STEP 1 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00000000 [ ] 
+Tentative time step : 0.01000000 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.171897724663e+04
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 3.821742193798e+02
+    1 KSP Residual norm 2.074294465651e-03
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 5.962718732545e+00
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.14379 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.417605764233e-04 
+      |Div|_2   = 5.272416130418e-03 
+   Momentum: 
+      |mRes|_2  = 5.962716401530e+00 
+--------------------------------------------------------------------------
+Actual time step : 0.01000 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.047346 sec)
+--------------------------------------------------------------------------
+================================= STEP 2 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01000000 [ ] 
+Tentative time step : 0.01100000 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.631279619817e+03
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 1.561199094471e+02
+    1 KSP Residual norm 6.906513822014e-04
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.548040682824e-02
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.07059 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.095674213112e-06 
+      |Div|_2   = 1.729160373727e-05 
+   Momentum: 
+      |mRes|_2  = 3.548040261466e-02 
+--------------------------------------------------------------------------
+Actual time step : 0.01100 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0487047 sec)
+--------------------------------------------------------------------------
+================================= STEP 3 =================================
+--------------------------------------------------------------------------
+Current time        : 0.02100000 [ ] 
+Tentative time step : 0.01210000 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.742249106617e+02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 1.893029490028e+00
+    1 KSP Residual norm 1.160779504365e-05
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 7.540136259097e-03
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.07032 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.317832315495e-06 
+      |Div|_2   = 7.819758479262e-06 
+   Momentum: 
+      |mRes|_2  = 7.540132204220e-03 
+--------------------------------------------------------------------------
+Actual time step : 0.01210 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0537053 sec)
+--------------------------------------------------------------------------
+================================= STEP 4 =================================
+--------------------------------------------------------------------------
+Current time        : 0.03310000 [ ] 
+Tentative time step : 0.01331000 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.955468043626e+02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 2.196772306586e+00
+    1 KSP Residual norm 1.433546593123e-05
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 8.351754481255e-03
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.06136 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.550491256941e-06 
+      |Div|_2   = 8.882436337562e-06 
+   Momentum: 
+      |mRes|_2  = 8.351749757835e-03 
+--------------------------------------------------------------------------
+Actual time step : 0.01331 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0550287 sec)
+--------------------------------------------------------------------------
+================================= STEP 5 =================================
+--------------------------------------------------------------------------
+Current time        : 0.04641000 [ ] 
+Tentative time step : 0.01464100 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.209940492215e+02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 2.588835403967e+00
+    1 KSP Residual norm 1.835700357827e-05
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 9.282765257119e-03
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.05881 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.851348187198e-06 
+      |Div|_2   = 1.031436455455e-05 
+   Momentum: 
+      |mRes|_2  = 9.282759526814e-03 
+--------------------------------------------------------------------------
+Actual time step : 0.01464 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0547189 sec)
+--------------------------------------------------------------------------
+================================= STEP 6 =================================
+--------------------------------------------------------------------------
+Current time        : 0.06105100 [ ] 
+Tentative time step : 0.01610510 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.517769605504e+02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 3.106296145330e+00
+    1 KSP Residual norm 2.424378552634e-05
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.035908107469e-02
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.05903 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.248288758944e-06 
+      |Div|_2   = 1.229419781353e-05 
+   Momentum: 
+      |mRes|_2  = 1.035907377929e-02 
+--------------------------------------------------------------------------
+Actual time step : 0.01611 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0536408 sec)
+--------------------------------------------------------------------------
+================================= STEP 7 =================================
+--------------------------------------------------------------------------
+Current time        : 0.07715610 [ ] 
+Tentative time step : 0.01771561 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.896148207436e+02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 3.806049801666e+00
+    1 KSP Residual norm 3.295521456616e-05
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 1.161314285252e-02
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.05861 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.782534345824e-06 
+      |Div|_2   = 1.510077568713e-05 
+   Momentum: 
+      |mRes|_2  = 1.161313303461e-02 
+--------------------------------------------------------------------------
+Actual time step : 0.01772 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0578885 sec)
+--------------------------------------------------------------------------
+================================= STEP 8 =================================
+--------------------------------------------------------------------------
+Current time        : 0.09487171 [ ] 
+Tentative time step : 0.01948717 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.341690911508e+04
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 1.805261748882e+02
+    1 KSP Residual norm 1.473982954338e-03
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 3.801206344019e-01
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.06418 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.719717533375e-04 
+      |Div|_2   = 8.729197104715e-04 
+   Momentum: 
+      |mRes|_2  = 3.801196321019e-01 
+--------------------------------------------------------------------------
+Actual time step : 0.01949 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0564651 sec)
+--------------------------------------------------------------------------
+================================= STEP 9 =================================
+--------------------------------------------------------------------------
+Current time        : 0.11435888 [ ] 
+Tentative time step : 0.02143589 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 6.069507346896e+03
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 8.224179357513e+01
+    1 KSP Residual norm 1.256786165295e-03
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 7.658282688830e-02
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.05254 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.879197041736e-05 
+      |Div|_2   = 3.948470584399e-04 
+   Momentum: 
+      |mRes|_2  = 7.658180900190e-02 
+--------------------------------------------------------------------------
+Actual time step : 0.02144 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.060591 sec)
+--------------------------------------------------------------------------
+================================ STEP 10 =================================
+--------------------------------------------------------------------------
+Current time        : 0.13579477 [ ] 
+Tentative time step : 0.02357948 [ ] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 8.841328365968e+02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 1.516042845075e+01
+    1 KSP Residual norm 1.174048640479e-04
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 1
+  1 SNES Function norm 4.995654460701e-03
+--------------------------------------------------------------------------
+SNES Convergence Reason : maximum iterations reached
+Number of iterations    : 1
+SNES solution time      : 1.0559 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.762317991407e-05 
+      |Div|_2   = 8.042278577964e-05 
+   Momentum: 
+      |mRes|_2  = 4.995007073693e-03 
+--------------------------------------------------------------------------
+Actual time step : 0.02358 [ ] 
+--------------------------------------------------------------------------
+Saving output ... done (0.0586305 sec)
+--------------------------------------------------------------------------
+=========================== SOLUTION IS DONE! ============================
+--------------------------------------------------------------------------
+Total solution time : 11.453 (sec) 
+--------------------------------------------------------------------------
+WARNING! There are options you set that were not used!
+WARNING! could be spelling mistake, etc!
+There are 6 unused database options. They are:
+Option left: name:-mat_product_algorithm value: scalable source: code
+Option left: name:-matmatmatmult_via value: scalable source: code
+Option left: name:-matmatmult_via value: scalable source: code
+Option left: name:-ParamFile value: 3D_push_block.dat source: code
+Option left: name:-snes_linesearch_maxstep value: 1.0 source: code
+Option left: name:-snes_linesearch_type value: basic source: code


### PR DESCRIPTION
This commit extends the Bezier block boundary condition to support full 3D path movement in addition to the existing 2D (x-y plane) mode. 

The updated 3D push block function will be useful to push the block along the z-direction (vertical direction) to mimic crustal upward indentation process in a 2D model. It is also potentially able to impose a dip-slip motion (motion within the x-z plane) along a shear zone.

## Changes

### Source code (`src/bc.cpp`, `src/bc.h`)

- Add `path_dim` parameter to `BCBlock` structure to specify path dimension
  - `path_dim = 2` (default): 2D path in x-y plane, `path` contains (x,y) coordinates
  - `path_dim = 3`: 3D path, `path` contains (x,y,z) coordinates
- Update `BCBlockCreate()` to parse `path_dim` and validate input (must be 2 or 3)
- Update `BCBlockGetPosition()` to compute 3D positions when `path_dim = 3`
- Update `BCBlockGetVelocity()` to compute full 3D velocities (vx, vy, vz)
- Add `BCBlockPrint()` function to display Bezier block configuration
- In 3D mode, `bot` and `top` z-coordinates move with the path

### Tests (`test/t34_3D_2D_push_block/`)

- Add a new test folder `t34_3D_2D_push_block`, which contains two dat files:
- `2D_push_block.dat`: Test case with `path_dim = 2` (push along x-axis only, to ensure the default, backward compatibility)
- `3D_push_block.dat`: Test case with `path_dim = 3` (push in x, y, z directions)
- Add corresponding expected output files for both tests

### Test runner (`test/runtests.jl`)

- Update testset name to `t34_3D_2D_push_block`
- Add test for 2D push block (`2D_push_block.dat`)
- Add test for 3D push block (`3D_push_block.dat`)

### Documentation (`input_models/input/lamem_input.dat`)

- Add documentation for `path_dim` parameter in BCBlock section
- Document both 2D and 3D path modes

## Usage Example

2D mode (default, x-y plane movement):
```
<BCBlockStart>
    path_dim = 2
    path     = 0.0 0.0 0.0 10.0   # (x0,y0) (x1,y1)
    ...
<BCBlockEnd>
```

3D mode (full x-y-z movement):
```
<BCBlockStart>
    path_dim = 3
    path     = 0.5 0.5 0.5 0.7 0.7 0.7   # (x0,y0,z0) (x1,y1,z1)
    ...
<BCBlockEnd>
```

The 3D_push_block.dat pushes the block along a 3D oblique (+x, +y and +z) direction, with gravity enable along -z direction. Result is below:


https://github.com/user-attachments/assets/125d6db7-b04a-41f6-bd23-563495d3c39e


