### PR TITLE
Update .zenodo.json to remove a trailing comma

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -31,5 +31,5 @@
     "id": "MIT"
   },
   "upload_type": "software",
-  "access_right": "open",
+  "access_right": "open"
 }


### PR DESCRIPTION
A quick fix to remove the trailing comma in .zenodo.json for Zenodo validation