### PR TITLE
Add slope-dependent erosion to the free surface

### DIFF
--- a/info/options/input_file.dat
+++ b/info/options/input_file.dat
@@ -138,6 +138,12 @@
     er_x_min           = -10 -10 -10      # minimum x-coordinates for erosion (model 3 only, one per phase)
     er_x_max           = 10  10  10       # maximum x-coordinates for erosion (model 3 only, one per phase)
 
+    # Slope-dependent erosion: E [m/yr] = constant_slope * slope^n_slope, slope = |grad(topo)| (dimensionless)
+    # Independent of erosion_model (can run on top of it); applied after erosion, before sedimentation and topographic diffusion
+    slope_dependent_erosion = 0           # slope-dependent erosion flag [0-none (default), 1-active]
+    constant_slope          = 1.0         # erosion constant [m/yr] (optional, default 1.0; NOTE: input in m/yr, unlike er_rates/sed_rates in cm/yr)
+    n_slope                 = 1.0         # slope power exponent [-] (optional, default 1.0)
+
     sediment_model     = 1                # sedimentation model [0-none (dafault), 1-prescribed rate with given level, 2-cont. margin]
     sed_num_layers     = 3                # number of sediment layers
     sed_time_delims    = 0.5   2.5        # sediment layers time delimiters (one less than number)

--- a/src/LaMEMLib.cpp
+++ b/src/LaMEMLib.cpp
@@ -700,6 +700,9 @@ PetscErrorCode LaMEMLibSolve(LaMEMLib *lm, void *param)
 		// apply erosion to the free surface
 		PetscCall(FreeSurfAppErosion(&lm->surf));
 
+		// apply slope-dependent erosion to the free surface
+		PetscCall(FreeSurfAppSlopeErosion(&lm->surf));
+
 		// apply sedimentation to the free surface
 		PetscCall(FreeSurfAppSedimentation(&lm->surf));
 

--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -24,8 +24,9 @@
 //---------------------------------------------------------------------------
 PetscErrorCode FreeSurfCreate(FreeSurf *surf, FB *fb)
 {
-	Scaling  *scal;
-	PetscInt  maxPhaseID, jj;
+	Scaling     *scal;
+	PetscInt     maxPhaseID, jj;
+	PetscScalar  m_yr = 1.0, cslope;
 
 	PetscFunctionBeginUser;
 
@@ -95,6 +96,24 @@ PetscErrorCode FreeSurfCreate(FreeSurf *surf, FB *fb)
 		PetscCall(getScalarParam(fb, _REQUIRED_, "sed_rates2nd",        surf->sedRates2nd,   surf->numLayers,   scal->velocity));
 	}
 
+	PetscCall(getIntParam(fb, _OPTIONAL_, "slope_dependent_erosion", &surf->slope_dependent_erosion, 1, 1));
+
+	if(surf->slope_dependent_erosion)
+	{
+		// characteristic velocity expressed in [m/yr] (input unit of constant_slope);
+		// in non-dimensional mode input is taken as-is
+		m_yr = scal->length_si/scal->time_si;
+		if(scal->utype != _NONE_) m_yr *= 3600.0*24.0*365.25;
+
+		cslope        = 1.0; // default: 1 [m/yr]
+		surf->n_slope = 1.0; // default exponent
+
+		PetscCall(getScalarParam(fb, _OPTIONAL_, "constant_slope", &cslope,        1, 1.0));
+		PetscCall(getScalarParam(fb, _OPTIONAL_, "n_slope",        &surf->n_slope, 1, 1.0));
+
+		surf->constant_slope = cslope/m_yr;
+	}
+
 	PetscCall(getIntParam(fb, _OPTIONAL_, "topo_diff", &surf->topo_diff, 1, 1));
 
 	if(surf->topo_diff)
@@ -132,6 +151,11 @@ PetscErrorCode FreeSurfCreate(FreeSurf *surf, FB *fb)
 	if(surf->numLayers) PetscPrintf(PETSC_COMM_WORLD, "   Number of sediment layers : %" PetscInt_FMT " \n",  surf->numLayers);
 	if(surf->phaseCorr) PetscPrintf(PETSC_COMM_WORLD, "   Correct marker phases     @ \n");
 	if(surf->MaxAngle)  PetscPrintf(PETSC_COMM_WORLD, "   Maximum surface slope     : %g %s\n",  surf->MaxAngle*scal->angle, scal->lbl_angle);
+
+	PetscPrintf(PETSC_COMM_WORLD, "   Slope-dependent erosion   : ");
+	if(!surf->slope_dependent_erosion) PetscPrintf(PETSC_COMM_WORLD, "none\n");
+	else                               PetscPrintf(PETSC_COMM_WORLD, "active (E = %g [m/yr] * slope^%g)\n",
+	                                   surf->constant_slope*m_yr, surf->n_slope);
 
 	PetscPrintf(PETSC_COMM_WORLD, "   Topographic diffusion     : ");
 	if(!surf->topo_diff) PetscPrintf(PETSC_COMM_WORLD, "none\n");
@@ -990,6 +1014,188 @@ PetscErrorCode FreeSurfAppErosion(FreeSurf *surf)
 		PetscPrintf(PETSC_COMM_WORLD, "  X-coordinate range:  [%e, %e] %s\n",
 			xmin*scal->length, xmax*scal->length, scal->lbl_length);
 	}
+
+	PetscFunctionReturn(0);
+}
+//---------------------------------------------------------------------------
+PetscErrorCode FreeSurfAppSlopeErosion(FreeSurf *surf)
+{
+	// Apply slope-dependent erosion to the internal free surface:
+	// E = constant_slope * slope^n_slope, slope = |grad(topo)| (dimensionless).
+	// Runs on top of any erosion model. Activated when slope_dependent_erosion = 1.
+	// Explicit update with sub-stepping: the vertical drop per sub-step is limited
+	// to half the minimum horizontal grid spacing, so slopes change by at most O(1)
+	// between slope re-evaluations (valid for any n_slope, unlike a formal
+	// Hamilton-Jacobi CFL, which is ill-defined for n_slope < 1).
+
+	JacRes      *jr;
+	FDSTAG      *fs;
+	Scaling     *scal;
+	PetscScalar ***topo, ***topo_old;
+	PetscScalar dt, gx, gy, slope, z, zbot, ztop, m_yr;
+	PetscScalar slope_max_loc, slope_max, E_max, dt_cfl, dt_solve;
+	PetscScalar dx_min_loc, dy_min_loc, dx_min, dy_min, d_min;
+	PetscInt    L, i, j, nx, ny, sx, sy, sz;
+	PetscInt    I, I1, I2, J, J1, J2, mx, my;
+	PetscInt    ksolve, nsolve, ii, jj;
+
+	PetscFunctionBeginUser;
+
+	// free surface and slope-dependent erosion cases only
+	if(!surf->UseFreeSurf)             PetscFunctionReturn(0);
+	if(!surf->slope_dependent_erosion) PetscFunctionReturn(0);
+
+	// access context
+	jr   = surf->jr;
+	fs   = jr->fs;
+	dt   = jr->ts->dt;
+	L    = (PetscInt)fs->dsz.rank;
+	mx   = fs->dsx.tnods;
+	my   = fs->dsy.tnods;
+	scal = jr->scal;
+
+	// get box z-bounds for clamping
+	PetscCall(FDSTAGGetGlobalBox(fs, NULL, NULL, &zbot, NULL, NULL, &ztop));
+
+	// get local domain corners
+	PetscCall(DMDAGetCorners(fs->DA_COR, &sx, &sy, &sz, &nx, &ny, NULL));
+
+	// find local minimum node spacing in x and y (for sub-step limit)
+	dx_min_loc = 1.0e+30;
+	for(ii = 0; ii < fs->dsx.nnods - 1; ii++)
+	{
+		PetscScalar d = fs->dsx.ncoor[ii+1] - fs->dsx.ncoor[ii];
+		if(d < dx_min_loc) dx_min_loc = d;
+	}
+	dy_min_loc = 1.0e+30;
+	for(jj = 0; jj < fs->dsy.nnods - 1; jj++)
+	{
+		PetscScalar d = fs->dsy.ncoor[jj+1] - fs->dsy.ncoor[jj];
+		if(d < dy_min_loc) dy_min_loc = d;
+	}
+
+	// find local maximum slope
+	slope_max_loc = 0.0;
+
+	PetscCall(DMDAVecGetArray(surf->DA_SURF, surf->ltopo, &topo_old));
+
+	START_PLANE_LOOP
+	{
+		I  = i;
+		I1 = I-1; if(I1 < 0)   I1 = I;
+		I2 = I+1; if(I2 >= mx) I2 = I;
+		J  = j;
+		J1 = J-1; if(J1 < 0)   J1 = J;
+		J2 = J+1; if(J2 >= my) J2 = J;
+
+		gx = 0.0;
+		if(I1 != I2)
+		{
+			gx = (topo_old[L][J][I2] - topo_old[L][J][I1])
+			   / (COORD_NODE(I2, sx, fs->dsx) - COORD_NODE(I1, sx, fs->dsx));
+		}
+		gy = 0.0;
+		if(J1 != J2)
+		{
+			gy = (topo_old[L][J2][I] - topo_old[L][J1][I])
+			   / (COORD_NODE(J2, sy, fs->dsy) - COORD_NODE(J1, sy, fs->dsy));
+		}
+
+		slope = PetscSqrtScalar(gx*gx + gy*gy);
+
+		if(slope > slope_max_loc) slope_max_loc = slope;
+	}
+	END_PLANE_LOOP
+
+	PetscCall(DMDAVecRestoreArray(surf->DA_SURF, surf->ltopo, &topo_old));
+
+	// global minima/maximum across all processors
+	PetscCallMPI(MPI_Allreduce(&dx_min_loc,    &dx_min,    1, MPIU_SCALAR, MPI_MIN, PETSC_COMM_WORLD));
+	PetscCallMPI(MPI_Allreduce(&dy_min_loc,    &dy_min,    1, MPIU_SCALAR, MPI_MIN, PETSC_COMM_WORLD));
+	PetscCallMPI(MPI_Allreduce(&slope_max_loc, &slope_max, 1, MPIU_SCALAR, MPI_MAX, PETSC_COMM_WORLD));
+
+	// maximum erosion rate (conservative estimate; slopes generally decay as erosion proceeds)
+	E_max = 0.0;
+	if(slope_max > 0.0) E_max = surf->constant_slope*PetscPowScalar(slope_max, surf->n_slope);
+
+	// number of sub-steps: limit vertical drop per sub-step to half the minimum spacing
+	d_min  = (dx_min < dy_min) ? dx_min : dy_min;
+	nsolve = 1;
+	if(E_max > 0.0)
+	{
+		dt_cfl = 0.5*d_min/E_max;
+		if(dt_cfl < dt) nsolve = (PetscInt)PetscCeilReal(dt/dt_cfl);
+	}
+	dt_solve = dt/(PetscScalar)nsolve;
+
+	// sub-stepping loop
+	for(ksolve = 0; ksolve < nsolve; ksolve++)
+	{
+		// read from ltopo (includes ghost cells), write to gtopo
+		PetscCall(DMDAVecGetArray(surf->DA_SURF, surf->gtopo, &topo));
+		PetscCall(DMDAVecGetArray(surf->DA_SURF, surf->ltopo, &topo_old));
+
+		START_PLANE_LOOP
+		{
+			I  = i;
+			I1 = I-1; if(I1 < 0)   I1 = I;
+			I2 = I+1; if(I2 >= mx) I2 = I;
+			J  = j;
+			J1 = J-1; if(J1 < 0)   J1 = J;
+			J2 = J+1; if(J2 >= my) J2 = J;
+
+			// topographic gradient (centered differences; one-sided at global boundaries)
+			gx = 0.0;
+			if(I1 != I2)
+			{
+				gx = (topo_old[L][J][I2] - topo_old[L][J][I1])
+				   / (COORD_NODE(I2, sx, fs->dsx) - COORD_NODE(I1, sx, fs->dsx));
+			}
+			gy = 0.0;
+			if(J1 != J2)
+			{
+				gy = (topo_old[L][J2][I] - topo_old[L][J1][I])
+				   / (COORD_NODE(J2, sy, fs->dsy) - COORD_NODE(J1, sy, fs->dsy));
+			}
+
+			// slope magnitude (dimensionless)
+			slope = PetscSqrtScalar(gx*gx + gy*gy);
+
+			// get topography
+			z = topo_old[L][J][I];
+
+			// erode with slope-dependent rate
+			if(slope > 0.0)
+			{
+				z -= surf->constant_slope*PetscPowScalar(slope, surf->n_slope)*dt_solve;
+			}
+
+			// check if internal free surface goes outside the model domain
+			if(z > ztop) z = ztop;
+			if(z < zbot) z = zbot;
+
+			// store updated topography
+			topo[L][j][i] = z;
+		}
+		END_PLANE_LOOP
+
+		// restore access
+		PetscCall(DMDAVecRestoreArray(surf->DA_SURF, surf->gtopo, &topo));
+		PetscCall(DMDAVecRestoreArray(surf->DA_SURF, surf->ltopo, &topo_old));
+
+		// refresh ghost cells before next sub-step
+		GLOBAL_TO_LOCAL(surf->DA_SURF, surf->gtopo, surf->ltopo);
+	}
+
+	// compute & store average topography
+	PetscCall(FreeSurfGetAvgTopo(surf));
+
+	// characteristic velocity expressed in [m/yr] for printing
+	m_yr = scal->length_si/scal->time_si;
+	if(scal->utype != _NONE_) m_yr *= 3600.0*24.0*365.25;
+
+	PetscPrintf(PETSC_COMM_WORLD, "Applying slope-dependent erosion (E = %g [m/yr] * slope^%g) in %" PetscInt_FMT " sub-step(s).\n",
+		surf->constant_slope*m_yr, surf->n_slope, nsolve);
 
 	PetscFunctionReturn(0);
 }

--- a/src/surf.h
+++ b/src/surf.h
@@ -60,6 +60,11 @@ struct FreeSurf
 	PetscScalar hDown;                      // down dip thickness of sediment cover
 	PetscScalar dTrans;                     // half of transition zone
 
+	// slope-dependent erosion parameters
+	PetscInt    slope_dependent_erosion; // slope-dependent erosion flag [0-none, 1-active]
+	PetscScalar constant_slope;          // erosion constant (non-dimensional, input in [m/yr])
+	PetscScalar n_slope;                 // slope power exponent (dimensionless)
+
 	// topographic diffusion parameters
 	PetscInt    topo_diff;        // topographic diffusion flag [0-none, 1-active]
 	PetscScalar topo_diffusivity; // topographic diffusivity (non-dimensional, input in [m^2/s])
@@ -104,6 +109,9 @@ PetscErrorCode FreeSurfGetAirPhaseRatio(FreeSurf *surf);
 
 // apply erosion to the free surface
 PetscErrorCode FreeSurfAppErosion(FreeSurf *surf);
+
+// apply slope-dependent erosion to the free surface
+PetscErrorCode FreeSurfAppSlopeErosion(FreeSurf *surf);
 
 // apply sedimentation to the free surface
 PetscErrorCode FreeSurfAppSedimentation(FreeSurf *surf);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1428,6 +1428,43 @@ end
         create_expected_file=update_expected, clean_dir=clean_files)
 end
 #---------------------------------------------------------------------------
+@testset "t37_slope_dependent_erosion" begin
+    # Slope-dependent erosion (slope_dependent_erosion = 1):
+    # E [m/yr] = constant_slope * slope^n_slope, slope = |grad(topo)|.
+    # A semicircular dome (same initial topography as t35_TopoDiffusion) is
+    # eroded on its flanks where the slope is largest, while the flat far field
+    # stays untouched. Guards FreeSurfAppSlopeErosion in src/surf.cpp (m/yr unit
+    # conversion, gradient stencil, and increment-limited sub-stepping), combined
+    # with 45-degree max-angle smoothing as in production use (and t35).
+    # Analytic validation of this setup: with smoothing disabled the first-step
+    # increment matches E*dt = 0.1 km * slope^2 to <0.2 m per node (flats
+    # untouched); with the 45-degree smoothing active, nodes steeper than tan(45)
+    # additionally exchange material with their neighbors (up to ~30 m per step).
+    cd(test_dir)
+    dir = "t37_slope_dependent_erosion"
+    include(joinpath(dir, "t37_CreateSetup.jl"))
+
+    keywords = ("|Div|_inf", "|Div|_2", "|mRes|_2")
+    acc      = ((rtol=1e-6, atol=1e-6), (rtol=1e-5, atol=5e-5), (rtol=2.5e-4, atol=1e-4))
+
+    ParamFile = "slope_dependent_erosion.dat"
+    topo_file = "t37_topo.bin"
+
+    t37_CreateSetup(dir, topo_file)
+
+    @test perform_lamem_test(dir, ParamFile, "slope_dependent_erosion_opt";
+        keywords = keywords,
+        accuracy = acc,
+        cores    = 1,
+        opt      = true,
+        mpiexec  = mpiexec,
+        create_expected_file=update_expected, clean_dir=clean_files)
+
+    if clean_files
+        rm(joinpath(dir,topo_file))
+    end
+end
+#---------------------------------------------------------------------------
 end
 #---------------------------------------------------------------------------
 

--- a/test/t37_slope_dependent_erosion/slope_dependent_erosion.dat
+++ b/test/t37_slope_dependent_erosion/slope_dependent_erosion.dat
@@ -1,0 +1,150 @@
+#===============================================================================
+# Scaling
+#===============================================================================
+
+    units            = geo
+    unit_temperature = 1000
+    unit_length      = 1e3
+    unit_viscosity   = 1e20
+    unit_stress      = 1e9
+
+#===============================================================================
+# Time stepping parameters
+#===============================================================================
+
+    dt        = 0.002
+    dt_max    = 0.002
+    nstep_max = 10
+    nstep_out = 5
+
+#===============================================================================
+# Grid & discretization parameters
+#===============================================================================
+
+    nseg_x = 1
+    nseg_y = 1
+    nseg_z = 1
+
+    nel_x  = 64
+    nel_y  = 2
+    nel_z  = 35
+
+    coord_x = -100  100
+    coord_y =   -1    1
+    coord_z =  -20   15
+
+#===============================================================================
+# Free surface
+#===============================================================================
+
+    surf_use         = 1
+    surf_level       = 0
+    surf_air_phase   = 0
+    surf_corr_phase  = 1
+    surf_max_angle   = 45.0
+    surf_topo_file   = t37_topo.bin
+
+    # Slope-dependent erosion: E [m/yr] = constant_slope * slope^n_slope
+    slope_dependent_erosion = 1
+    constant_slope   = 0.05
+    n_slope          = 2.0
+
+#===============================================================================
+# Boundary conditions
+#===============================================================================
+
+    noslip = 0 0 0 0 1 0
+
+#===============================================================================
+# Solution parameters
+#===============================================================================
+
+    gravity      = 0.0 0.0 -9.81
+    FSSA         = 1.0
+    init_guess   = 1
+    eta_ref      = 1e20
+    eta_min      = 1e15
+    eta_max      = 1e25
+
+#===============================================================================
+# Markers (geometric setup)
+#===============================================================================
+
+    msetup      = geom
+    nmark_x     = 3
+    nmark_y     = 3
+    nmark_z     = 3
+    rand_noise  = 1
+    bg_phase    = 1
+    advect      = rk2
+    interp      = stag
+    mark_ctrl   = subgrid
+    nmark_lim   = 10 100
+    nmark_sub   = 3
+
+    # Air layer: everything above z = 0
+    <BoxStart>
+        phase  = 0
+        bounds = -100 100 -1 1 0 15
+    <BoxEnd>
+
+    # Crust_2 half-sphere: centred at (0, 0, 0), radius 10 km
+    # Lower half sits inside Crust_1; upper half protrudes into air
+    <SphereStart>
+        phase  = 2
+        radius = 10
+        center = 0 0 0
+    <SphereEnd>
+
+#===============================================================================
+# Output
+#===============================================================================
+
+    out_file_name       = output
+    out_pvd             = 1
+    out_surf            = 1
+    out_surf_pvd        = 1
+    out_surf_topography = 1
+
+#===============================================================================
+# Material phases
+#===============================================================================
+
+    <MaterialStart>
+        ID   = 0
+        Name = Air
+        rho  = 50
+        eta  = 1e19
+    <MaterialEnd>
+
+    <MaterialStart>
+        ID   = 1
+        Name = Crust_1
+        rho  = 2700
+        eta  = 1e22
+    <MaterialEnd>
+
+    <MaterialStart>
+        ID   = 2
+        Name = Crust_2
+        rho  = 2700
+        eta  = 1e22
+    <MaterialEnd>
+
+
+#===============================================================================
+# Solver options
+#===============================================================================
+
+<SolverOptionsStart>
+
+	nonlinear_tolerances = 1e-4 1e-8  50      # rtol, atol, maxit
+	linear_tolerances    = 1e-6 1e-8  40      # rtol, atol, maxit
+	picard_to_newton     = 1e-4  5  1.2  20   # picard rtol, picard minit, newton rtol, newton maxit
+	monitor_solvers      = 1
+	stokes_solver        = block_direct
+	direct_solver_type   = mumps
+
+<SolverOptionsEnd>
+
+#===============================================================================

--- a/test/t37_slope_dependent_erosion/slope_dependent_erosion_opt.expected
+++ b/test/t37_slope_dependent_erosion/slope_dependent_erosion_opt.expected
@@ -1,0 +1,572 @@
+--------------------------------------------------------------------------
+Parsing input file : slope_dependent_erosion.dat 
+Finished parsing input file 
+--------------------------------------------------------------------------
+Parsing PETSc options
+Total number of options added: 0
+--------------------------------------------------------------------------
+#PETSc Option Table entries:
+-bf_vs_type user # (source: code)
+-jp_pgamma 1000 # (source: code)
+-jp_type bf # (source: code)
+-js_ksp_atol 1e-08 # (source: code)
+-js_ksp_converged_reason # (source: code)
+-js_ksp_max_it 40 # (source: code)
+-js_ksp_monitor # (source: code)
+-js_ksp_rtol 1e-06 # (source: code)
+-js_ksp_type fgmres # (source: code)
+-options_left # (source: code)
+-ParamFile slope_dependent_erosion.dat # (source: code)
+-snes_atol 1e-08 # (source: code)
+-snes_linesearch_max_it 5 # (source: code)
+-snes_linesearch_maxstep 1.0 # (source: code)
+-snes_linesearch_minlambda 0.05 # (source: code)
+-snes_linesearch_type l2 # (source: code)
+-snes_max_funcs 1000000000 # (source: code)
+-snes_max_it 50 # (source: code)
+-snes_monitor # (source: code)
+-snes_newton_maxit 20 # (source: code)
+-snes_newton_rtol 1.2 # (source: code)
+-snes_picard_minit 5 # (source: code)
+-snes_picard_rtol 0.0001 # (source: code)
+-snes_rtol 0.0001 # (source: code)
+-snes_stol 1e-32 # (source: code)
+-vs_ksp_type preonly # (source: code)
+-vs_pc_factor_mat_solver_type mumps # (source: code)
+-vs_pc_type lu # (source: code)
+#End of PETSc Option Table entries
+-------------------------------------------------------------------------- 
+                   Lithosphere and Mantle Evolution Model                   
+     Compiled: Date: Jul 11 2026 - Time: 12:37:15 	    
+     Version : 3.0.0 
+-------------------------------------------------------------------------- 
+        STAGGERED-GRID FINITE DIFFERENCE CANONICAL IMPLEMENTATION           
+-------------------------------------------------------------------------- 
+Scaling parameters:
+   Temperature : 1000. [C/K] 
+   Length      : 1000. [m] 
+   Viscosity   : 1e+20 [Pa*s] 
+   Stress      : 1e+09 [Pa] 
+--------------------------------------------------------------------------
+Time stepping parameters:
+   Simulation end time          : 0.02 [Myr] 
+   Maximum number of steps      : 10 
+   Time step                    : 0.002 [Myr] 
+   Minimum time step            : 4e-05 [Myr] 
+   Maximum time step            : 0.002 [Myr] 
+   Time step increase factor    : 0.1 
+   CFL criterion                : 0.5 
+   CFLMAX (fixed time steps)    : 0.8 
+   Output every [n] steps       : 5 
+   Output [n] initial steps     : 1 
+--------------------------------------------------------------------------
+Grid parameters:
+   Total number of cpu                  : 1 
+   Processor grid  [nx, ny, nz]         : [1, 1, 1]
+   Fine grid cells [nx, ny, nz]         : [64, 2, 35]
+   Number of cells                      :  4480
+   Number of faces                      :  15878
+   Maximum cell aspect ratio            :  3.12500
+   Lower coordinate bounds [bx, by, bz] : [-100., -1., -20.]
+   Upper coordinate bounds [ex, ey, ez] : [100., 1., 15.]
+--------------------------------------------------------------------------
+Material parameters: 
+
+   Phase ID : 0     --   Air 
+   (dens)   : rho = 50. [kg/m^3]  
+   (diff)   : eta = 1e+19 [Pa*s]  Bd = 5e-20 [1/Pa/s]  
+
+   Phase ID : 1     --   Crust_1 
+   (dens)   : rho = 2700. [kg/m^3]  
+   (diff)   : eta = 1e+22 [Pa*s]  Bd = 5e-23 [1/Pa/s]  
+
+   Phase ID : 2     --   Crust_2 
+   (dens)   : rho = 2700. [kg/m^3]  
+   (diff)   : eta = 1e+22 [Pa*s]  Bd = 5e-23 [1/Pa/s]  
+
+--------------------------------------------------------------------------
+Free surface parameters: 
+   Sticky air phase ID       : 0 
+   Initial surface level     : 0. [km] 
+   Erosion model             : none
+   Sedimentation model       : none
+   Correct marker phases     @ 
+   Maximum surface slope     : 45. [deg]
+   Slope-dependent erosion   : active (E = 0.05 [m/yr] * slope^2.)
+   Topographic diffusion     : none
+--------------------------------------------------------------------------
+Loading topography redundantly from file(s) <t37_topo.bin> ... done (0.000167779 sec)
+--------------------------------------------------------------------------
+Boundary condition parameters: 
+   No-slip boundary mask [lt rt ft bk bm tp]  : 0 0 0 0 1 0 
+--------------------------------------------------------------------------
+Solution parameters & controls:
+   Gravity [gx, gy, gz]                    : [0., 0., -9.81] [m/s^2] 
+   Surface stabilization (FSSA)            :  1. 
+   Compute initial guess                   @ 
+   Use lithostatic pressure for creep      @ 
+   Minimum viscosity                       : 1e+15 [Pa*s] 
+   Maximum viscosity                       : 1e+25 [Pa*s] 
+   Reference viscosity (initial guess)     : 1e+20 [Pa*s] 
+   Max. melt fraction (viscosity, density) : 1.    
+   Rheology iteration number               : 25  
+   Rheology iteration tolerance            : 1e-06    
+   Ground water level type                 : none 
+--------------------------------------------------------------------------
+Advection parameters:
+   Advection scheme              : Runge-Kutta 2-nd order
+   Marker setup scheme           : geometric primitives
+   Velocity interpolation scheme : STAG (linear)
+   Marker control type           : subgrid 
+   Markers per cell [nx, ny, nz] : [3, 3, 3] 
+   Marker distribution type      : random noise
+   Background phase ID           : 1 
+--------------------------------------------------------------------------
+Reading geometric primitives ... done (0.00190493 sec)
+--------------------------------------------------------------------------
+Output parameters:
+   Output file name                        : output 
+   Write .pvd file                         : yes 
+   Phase                                   @ 
+   Total effective viscosity               @ 
+   Creep effective viscosity               @ 
+   Velocity                                @ 
+   Pressure                                @ 
+--------------------------------------------------------------------------
+Surface output parameters:
+   Write .pvd file : yes 
+   Velocity        @ 
+   Topography      @ 
+   Amplitude       @ 
+--------------------------------------------------------------------------
+--------------------------------------------------------------------------
+Preconditioner parameters: 
+   Picard operator type          : assembled
+   Preconditioner type           : block factorization
+   Block factorization type      : upper 
+   Velocity preconditioner       : user-defined
+   Schur preconditioner          : inverse viscosity
+   Penalty parameter (pgamma)    : 1.000000e+03
+--------------------------------------------------------------------------
+============================== INITIAL GUESS =============================
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.340412783839e+00
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 1.340412783839e+00
+    1 KSP Residual norm 1.333376910283e+00
+    2 KSP Residual norm 1.215281498992e-02
+    3 KSP Residual norm 4.124883459334e-04
+    4 KSP Residual norm 1.256319591344e-06
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 4
+  1 SNES Function norm 1.256319592107e-06
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 1
+SNES solution time      : 0.288174 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 5.109329935613e-08 
+      |Div|_2   = 1.256319592041e-06 
+   Momentum: 
+      |mRes|_2  = 1.279641928468e-11 
+--------------------------------------------------------------------------
+Saving output ... done (0.00236128 sec)
+--------------------------------------------------------------------------
+================================= STEP 1 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00000000 [Myr] 
+Tentative time step : 0.00200000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.401292084124e+01
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 1.401292084124e+01
+    1 KSP Residual norm 1.494409742176e-01
+    2 KSP Residual norm 2.842255327850e-02
+    3 KSP Residual norm 2.909333950025e-03
+    4 KSP Residual norm 5.314272224763e-05
+    5 KSP Residual norm 1.198735501220e-05
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 5
+  1 SNES Function norm 1.198735513038e-05
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 1
+SNES solution time      : 0.213156 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.531533745476e-07 
+      |Div|_2   = 3.365170880698e-06 
+   Momentum: 
+      |mRes|_2  = 1.150531650871e-05 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Applying slope-dependent erosion (E = 0.05 [m/yr] * slope^2.) in 1 sub-step(s).
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 209 markers and merged 0 markers in 4.7960e-03 s
+--------------------------------------------------------------------------
+Saving output ... done (0.00206317 sec)
+--------------------------------------------------------------------------
+================================= STEP 2 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00200000 [Myr] 
+Tentative time step : 0.00200000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 3.526023821110e-02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 3.526023821110e-02
+    1 KSP Residual norm 2.682260897028e-02
+    2 KSP Residual norm 1.914032397857e-04
+    3 KSP Residual norm 6.414626276091e-05
+    4 KSP Residual norm 8.439635765790e-07
+    5 KSP Residual norm 5.920873845457e-07
+    6 KSP Residual norm 4.802005704654e-08
+    7 KSP Residual norm 4.202450513190e-08
+    8 KSP Residual norm 2.738808300994e-09
+    Linear js_ solve converged due to CONVERGED_ATOL iterations 8
+  1 SNES Function norm 2.738726548474e-09
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.24002 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.968385953775e-11 
+      |Div|_2   = 6.150755585033e-10 
+   Momentum: 
+      |mRes|_2  = 2.668764726357e-09 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Applying slope-dependent erosion (E = 0.05 [m/yr] * slope^2.) in 1 sub-step(s).
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 196 markers and merged 0 markers in 4.8807e-03 s
+--------------------------------------------------------------------------
+================================= STEP 3 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00400000 [Myr] 
+Tentative time step : 0.00200000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 4.515834978895e-02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 4.515834978895e-02
+    1 KSP Residual norm 3.066759650269e-02
+    2 KSP Residual norm 1.846243204900e-05
+    3 KSP Residual norm 1.760367884450e-05
+    4 KSP Residual norm 1.727769103508e-06
+    5 KSP Residual norm 1.697098701737e-06
+    6 KSP Residual norm 1.814499412488e-08
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 6
+  1 SNES Function norm 1.814498889332e-08
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 1
+SNES solution time      : 0.260662 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.461311705106e-08 
+      |Div|_2   = 1.785650266551e-08 
+   Momentum: 
+      |mRes|_2  = 3.222721597550e-09 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Applying slope-dependent erosion (E = 0.05 [m/yr] * slope^2.) in 1 sub-step(s).
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 189 markers and merged 0 markers in 4.9004e-03 s
+--------------------------------------------------------------------------
+================================= STEP 4 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00600000 [Myr] 
+Tentative time step : 0.00200000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.069125426078e-02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 1.069125426078e-02
+    1 KSP Residual norm 7.603919439992e-03
+    2 KSP Residual norm 4.152633059181e-05
+    3 KSP Residual norm 1.810160681198e-05
+    4 KSP Residual norm 2.491763870100e-07
+    5 KSP Residual norm 2.400040835744e-07
+    6 KSP Residual norm 2.434624741933e-08
+    7 KSP Residual norm 8.537529614025e-09
+    Linear js_ solve converged due to CONVERGED_ATOL iterations 7
+  1 SNES Function norm 8.536981019566e-09
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.232301 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.142513704087e-09 
+      |Div|_2   = 1.914464771773e-09 
+   Momentum: 
+      |mRes|_2  = 8.319547437576e-09 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Applying slope-dependent erosion (E = 0.05 [m/yr] * slope^2.) in 1 sub-step(s).
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 204 markers and merged 0 markers in 4.9485e-03 s
+--------------------------------------------------------------------------
+================================= STEP 5 =================================
+--------------------------------------------------------------------------
+Current time        : 0.00800000 [Myr] 
+Tentative time step : 0.00200000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 8.145035688626e-03
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 8.145035688626e-03
+    1 KSP Residual norm 6.740313693644e-03
+    2 KSP Residual norm 3.509933161252e-06
+    3 KSP Residual norm 3.501328521763e-06
+    4 KSP Residual norm 2.522434156715e-07
+    5 KSP Residual norm 2.472887067980e-07
+    6 KSP Residual norm 3.146339893567e-09
+    Linear js_ solve converged due to CONVERGED_ATOL iterations 6
+  1 SNES Function norm 3.146580844365e-09
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.223292 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.602165816900e-09 
+      |Div|_2   = 3.072884262008e-09 
+   Momentum: 
+      |mRes|_2  = 6.770179631544e-10 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Applying slope-dependent erosion (E = 0.05 [m/yr] * slope^2.) in 1 sub-step(s).
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 207 markers and merged 0 markers in 4.9880e-03 s
+--------------------------------------------------------------------------
+Saving output ... done (0.00206362 sec)
+--------------------------------------------------------------------------
+================================= STEP 6 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01000000 [Myr] 
+Tentative time step : 0.00200000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 2.463520037057e-02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 2.463520037057e-02
+    1 KSP Residual norm 2.318454326094e-02
+    2 KSP Residual norm 2.132510721830e-05
+    3 KSP Residual norm 2.056614971186e-05
+    4 KSP Residual norm 1.564777348115e-06
+    5 KSP Residual norm 1.497395702433e-06
+    6 KSP Residual norm 1.292409311509e-08
+    Linear js_ solve converged due to CONVERGED_RTOL iterations 6
+  1 SNES Function norm 1.292410793048e-08
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < rtol*||F_initial|| 
+Number of iterations    : 1
+SNES solution time      : 0.272789 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 3.941418972176e-09 
+      |Div|_2   = 1.118732223455e-08 
+   Momentum: 
+      |mRes|_2  = 6.471196722319e-09 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Applying slope-dependent erosion (E = 0.05 [m/yr] * slope^2.) in 1 sub-step(s).
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 220 markers and merged 0 markers in 5.0631e-03 s
+--------------------------------------------------------------------------
+================================= STEP 7 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01200000 [Myr] 
+Tentative time step : 0.00200000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 8.726741812899e-03
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 8.726741812899e-03
+    1 KSP Residual norm 6.810810057413e-03
+    2 KSP Residual norm 1.491169754894e-05
+    3 KSP Residual norm 1.216011944764e-05
+    4 KSP Residual norm 9.874664818315e-08
+    5 KSP Residual norm 9.708912824700e-08
+    6 KSP Residual norm 7.781859444824e-09
+    Linear js_ solve converged due to CONVERGED_ATOL iterations 6
+  1 SNES Function norm 7.782144499228e-09
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.222862 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.092765237580e-09 
+      |Div|_2   = 4.358595605405e-09 
+   Momentum: 
+      |mRes|_2  = 6.447047181106e-09 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Applying slope-dependent erosion (E = 0.05 [m/yr] * slope^2.) in 1 sub-step(s).
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 206 markers and merged 0 markers in 5.0931e-03 s
+--------------------------------------------------------------------------
+================================= STEP 8 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01400000 [Myr] 
+Tentative time step : 0.00200000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.749412838380e-03
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 7.749412838380e-03
+    1 KSP Residual norm 5.906612873248e-03
+    2 KSP Residual norm 7.731161438531e-06
+    3 KSP Residual norm 7.698385914684e-06
+    4 KSP Residual norm 8.260774955316e-08
+    5 KSP Residual norm 8.233711195285e-08
+    6 KSP Residual norm 3.444971883273e-09
+    Linear js_ solve converged due to CONVERGED_ATOL iterations 6
+  1 SNES Function norm 3.444502439406e-09
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.272312 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 1.561606223288e-09 
+      |Div|_2   = 2.801634133590e-09 
+   Momentum: 
+      |mRes|_2  = 2.003857089858e-09 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Applying slope-dependent erosion (E = 0.05 [m/yr] * slope^2.) in 1 sub-step(s).
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 181 markers and merged 0 markers in 5.0862e-03 s
+--------------------------------------------------------------------------
+================================= STEP 9 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01600000 [Myr] 
+Tentative time step : 0.00200000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 1.094096674804e-02
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 1.094096674804e-02
+    1 KSP Residual norm 8.836518360936e-03
+    2 KSP Residual norm 1.248624474469e-05
+    3 KSP Residual norm 1.209089931422e-05
+    4 KSP Residual norm 1.978643682959e-07
+    5 KSP Residual norm 1.950642106180e-07
+    6 KSP Residual norm 5.624119468320e-09
+    Linear js_ solve converged due to CONVERGED_ATOL iterations 6
+  1 SNES Function norm 5.624278224513e-09
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.223085 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 2.139778666239e-09 
+      |Div|_2   = 4.332908544363e-09 
+   Momentum: 
+      |mRes|_2  = 3.585862391799e-09 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Applying slope-dependent erosion (E = 0.05 [m/yr] * slope^2.) in 1 sub-step(s).
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 180 markers and merged 0 markers in 5.2468e-03 s
+--------------------------------------------------------------------------
+================================ STEP 10 =================================
+--------------------------------------------------------------------------
+Current time        : 0.01800000 [Myr] 
+Tentative time step : 0.00200000 [Myr] 
+--------------------------------------------------------------------------
+  0 SNES Function norm 7.038728143968e-03
+  0 PICARD ||F||/||F0||=1.000000e+00 
+    Residual norms for js_ solve.
+    0 KSP Residual norm 7.038728143968e-03
+    1 KSP Residual norm 6.109992396682e-03
+    2 KSP Residual norm 6.454528292254e-06
+    3 KSP Residual norm 6.429605692498e-06
+    4 KSP Residual norm 2.422382646438e-07
+    5 KSP Residual norm 2.380212547103e-07
+    6 KSP Residual norm 3.451499095499e-09
+    Linear js_ solve converged due to CONVERGED_ATOL iterations 6
+  1 SNES Function norm 3.451615372208e-09
+--------------------------------------------------------------------------
+SNES Convergence Reason : ||F|| < atol 
+Number of iterations    : 1
+SNES solution time      : 0.223562 (sec)
+--------------------------------------------------------------------------
+Residual summary: 
+   Continuity: 
+      |Div|_inf = 4.235322002507e-10 
+      |Div|_2   = 1.229538149554e-09 
+   Momentum: 
+      |mRes|_2  = 3.225195283460e-09 
+--------------------------------------------------------------------------
+Actual time step : 0.00200 [Myr] 
+--------------------------------------------------------------------------
+Applying slope-dependent erosion (E = 0.05 [m/yr] * slope^2.) in 1 sub-step(s).
+Performing marker control (subgrid algorithm)
+Marker control [0]: (subgrid) cloned 180 markers and merged 0 markers in 5.1854e-03 s
+--------------------------------------------------------------------------
+Saving output ... done (0.00208611 sec)
+--------------------------------------------------------------------------
+=========================== SOLUTION IS DONE! ============================
+--------------------------------------------------------------------------
+Total solution time : 3.55627 (sec) 
+--------------------------------------------------------------------------
+#PETSc Option Table entries:
+-bf_vs_type user # (source: code)
+-jp_pgamma 1000 # (source: code)
+-jp_type bf # (source: code)
+-js_ksp_atol 1e-08 # (source: code)
+-js_ksp_converged_reason # (source: code)
+-js_ksp_max_it 40 # (source: code)
+-js_ksp_monitor # (source: code)
+-js_ksp_rtol 1e-06 # (source: code)
+-js_ksp_type fgmres # (source: code)
+-options_left # (source: code)
+-ParamFile slope_dependent_erosion.dat # (source: code)
+-snes_atol 1e-08 # (source: code)
+-snes_linesearch_max_it 5 # (source: code)
+-snes_linesearch_maxstep 1.0 # (source: code)
+-snes_linesearch_minlambda 0.05 # (source: code)
+-snes_linesearch_type l2 # (source: code)
+-snes_max_funcs 1000000000 # (source: code)
+-snes_max_it 50 # (source: code)
+-snes_monitor # (source: code)
+-snes_newton_maxit 20 # (source: code)
+-snes_newton_rtol 1.2 # (source: code)
+-snes_picard_minit 5 # (source: code)
+-snes_picard_rtol 0.0001 # (source: code)
+-snes_rtol 0.0001 # (source: code)
+-snes_stol 1e-32 # (source: code)
+-vs_ksp_type preonly # (source: code)
+-vs_pc_factor_mat_solver_type mumps # (source: code)
+-vs_pc_type lu # (source: code)
+#End of PETSc Option Table entries
+WARNING! There are options you set that were not used!
+WARNING! could be spelling mistake, etc!
+There is one unused database option. It is:
+Option left: name:-ParamFile value: slope_dependent_erosion.dat source: code

--- a/test/t37_slope_dependent_erosion/t37_CreateSetup.jl
+++ b/test/t37_slope_dependent_erosion/t37_CreateSetup.jl
@@ -1,0 +1,32 @@
+using GeophysicalModelGenerator
+
+# Creates the initial topography file for the slope-dependent erosion test.
+# Same semicircular dome as t35_TopoDiffusion:
+#   z_topo(x) = sqrt(R^2 - x^2)  for |x| < R
+#   z_topo(x) = 0                 otherwise
+# where R = 10 km and the sphere centre is at the surface level z = 0.
+# Slope-dependent erosion (E = constant_slope * slope^n_slope) erodes the dome
+# flanks where the slope is largest, while the flat far field stays untouched.
+
+function t37_CreateSetup(dir, topo_file)
+
+    cur_dir = pwd()
+    cd(dir)
+
+    R      = 10.0                         # dome radius [km]
+    x_vals = collect(-100.0:1.0:100.0)    # 201 points covering model x-extent
+    y_vals = collect(-1.0:2.0:1.0)        # 2 points covering model y-extent
+
+    X_t, Y_t, Z_t = xyz_grid(x_vals, y_vals, 0)
+
+    Topo_z = zeros(length(x_vals), length(y_vals), 1)
+    for i in eachindex(x_vals)
+        z_surf = abs(x_vals[i]) < R ? sqrt(R^2 - x_vals[i]^2) : 0.0
+        Topo_z[i, :, 1] .= z_surf
+    end
+
+    Topo = CartData(X_t, Y_t, Z_t, (Topography=Topo_z,))
+    save_LaMEM_topography(Topo, topo_file)
+
+    cd(cur_dir)
+end


### PR DESCRIPTION
### Adds an optional slope-dependent erosion law:

`E [m/yr] = constant_slope * slope^n_slope`

where `slope = |grad(topo)|` (dimensionless), applied to the internal free surface. It is independent of `erosion_model` and is applied after other erosion processes, before sedimentation and topographic diffusion. Activated with `slope_dependent_erosion = 1` in the **Free Surface** section.

### New parameters introduced

- `constant_slope` (default `1.0`) is input in **m/yr** (unlike `er_rates`/`sed_rates`, which stay in **cm/yr**) and converted internally. The input unit of **m/yr** is to be consistent with the geomorological convention.

- `n_slope` (default `1.0`) is dimensionless. This is the power to the slope.

### Geological relevance

The slope-dependent erosion law can mimic the effect of the stream-power law on top of other erosion processes (hillslope diffusion, spatially limited erosion). The slope-dependent erosion works for both 2D (x-z profile case) and 3D, although a future FastScape coupling is a better way to deal with a 3D case.

### Implementation

- **`FreeSurfAppSlopeErosion` (`surf.cpp`)**: centered-difference gradient (one-sided at global boundaries), explicit update with increment-limited sub-stepping (vertical drop per sub-step capped at half the minimum horizontal grid spacing, slopes recomputed every sub-step).

### Tests

- **New test `t37_slope_dependent_erosion`**: semicircular dome (same initial topography as `t35_TopoDiffusion`) eroded with `n_slope = 2` and 45-degree max-angle smoothing. First-step increments were verified against the analytic `E*dt` to <0.2 m per node (with smoothing disabled), and parallel runs on 2/4 cores match the serial result.

### Documentation

- Documented the new parameters in `info/options/input_file.dat`.

### A movie shown below
- same initial dome-shaped topo as t35
- constant_slope   = 0.05 and n_slope  = 2.0
- surf_max_angle   = 45.0 activated
- topo diffusion is turned off

https://github.com/user-attachments/assets/7b0ecbe3-7227-4e59-ada0-9c63293591b6

