### PR TITLE
fix memory leak by adding missing restorearray calls

### DIFF
--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -1329,6 +1329,13 @@ PetscErrorCode PMatBlockAssemble(PMatBlock *P)
 	PetscCall(DMDAVecRestoreArray(fs->DA_Z,   md->bcvz,  &bcvz));
 	PetscCall(DMDAVecRestoreArray(fs->DA_CEN, md->bcp,   &bcp));
 
+	PetscCall(DMDAVecRestoreArray(fs->DA_CEN, md->Kb,    &vKb));
+	PetscCall(DMDAVecRestoreArray(fs->DA_CEN, md->rho,   &vrho));
+	PetscCall(DMDAVecRestoreArray(fs->DA_CEN, md->eta,   &veta));
+	PetscCall(DMDAVecRestoreArray(fs->DA_XY,  md->etaxy, &vetaxy));
+	PetscCall(DMDAVecRestoreArray(fs->DA_XZ,  md->etaxz, &vetaxz));
+	PetscCall(DMDAVecRestoreArray(fs->DA_YZ,  md->etayz, &vetayz));
+	
 	// assemble velocity-pressure matrix blocks, remove constrained rows
 	PetscCall(MatAIJAssemble(P->Avv, md->vNumSPC, md->vSPCListMat, 1.0));
 	PetscCall(MatAIJAssemble(P->Avp, md->vNumSPC, md->vSPCListMat, 0.0));


### PR DESCRIPTION
My memory usage on my runs (>1k timesteps) were blowing up and I found out that this was missing, after the fix i stopped seeing memory blow ups in my runs